### PR TITLE
Trinity.C: fix initialization of dirty_flags

### DIFF
--- a/src/Trinity.C/src/Storage/LocalStorage/LocalMemoryStorage.cpp
+++ b/src/Trinity.C/src/Storage/LocalStorage/LocalMemoryStorage.cpp
@@ -60,7 +60,7 @@ namespace Storage
                 hashtables[i].Initialize((uint32_t)(TrinityConfig::MemoryPoolSize >> 15), memory_trunks + i); // Default capacity = 256M >> 15 = 8192
             }
 
-            memset(dirty_flags, sizeof(int32_t) * trunk_count, 0);
+            memset(dirty_flags, 0, sizeof(int32_t) * trunk_count);
 
             disposed.store(false);
             initialized.store(true);


### PR DESCRIPTION
Corrects the order of arguments to memset. The flags were used
uninitialized before.