### PR TITLE
Update README build instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Please submit bugs and feature requests in [GitHub Issues](https://github.com/Mi
 
 ## Building for Windows
 
-Make sure Visual Studio 2015 is installed. To build the `.Net Framework 4.5.1` version, you can either built the 
+Make sure [Visual C++ 2015 Build Tools](http://landinghub.visualstudio.com/visual-cpp-build-tools) is installed for MSBuild and VC++ compiler toolchains. To build the `.Net Framework 4.5.1` version, you can either built the 
 projects (except `Trinity.Core.NETStandard.sln`) one by one with Visual Studio, or
 run `tools/build.bat`.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Please submit bugs and feature requests in [GitHub Issues](https://github.com/Mi
 
 ## Building for Windows
 
-To build the `.Net Framework 4.5.1` version, you can either built the 
+Make sure Visual Studio 2015 is installed. To build the `.Net Framework 4.5.1` version, you can either built the 
 projects (except `Trinity.Core.NETStandard.sln`) one by one with Visual Studio, or
 run `tools/build.bat`.
 

--- a/tools/build.bat
+++ b/tools/build.bat
@@ -4,7 +4,7 @@ if [%REPO_ROOT%] == [] (
 
 setlocal enabledelayedexpansion
 
-set MSBUILD_EXE="C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe"
+set MSBUILD_EXE="C:\Program Files (x86)\MSBuild\12.0\Bin\MSBuild.exe"
 set NUGET_EXE="%REPO_ROOT%\tools\NuGet.exe"
 
 if not exist %NUGET_EXE% (

--- a/tools/build.bat
+++ b/tools/build.bat
@@ -4,7 +4,7 @@ if [%REPO_ROOT%] == [] (
 
 setlocal enabledelayedexpansion
 
-set MSBUILD_EXE="C:\Program Files (x86)\MSBuild\12.0\Bin\MSBuild.exe"
+set MSBUILD_EXE="C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe"
 set NUGET_EXE="%REPO_ROOT%\tools\NuGet.exe"
 
 if not exist %NUGET_EXE% (


### PR DESCRIPTION
build.bat and vcxprojs implies building environment of visual studio 2015. Specify this requirement in README.txt.