### PR TITLE
Fix argument of MemoryCommit().

### DIFF
--- a/src/Trinity.C/src/Memory/Memory.cpp
+++ b/src/Trinity.C/src/Memory/Memory.cpp
@@ -151,7 +151,7 @@ namespace Memory
     the current commitment state of each page.
 
     ***************************************/
-    void * MemoryCommit(void * buf, uint64_t size)
+    void * MemoryCommit(void * buf, size_t size)
     {
 #if defined(TRINITY_PLATFORM_WINDOWS)
         //Commit the desired size, the actually allocated space will be larger(up to a whole page) than the desired size.

--- a/src/Trinity.C/src/Memory/Memory.cpp
+++ b/src/Trinity.C/src/Memory/Memory.cpp
@@ -151,7 +151,7 @@ namespace Memory
     the current commitment state of each page.
 
     ***************************************/
-    void * MemoryCommit(void * buf, size_t size)
+    void * MemoryCommit(void * buf, uint64_t size)
     {
 #if defined(TRINITY_PLATFORM_WINDOWS)
         //Commit the desired size, the actually allocated space will be larger(up to a whole page) than the desired size.

--- a/src/Trinity.C/src/Memory/Memory.h
+++ b/src/Trinity.C/src/Memory/Memory.h
@@ -52,7 +52,7 @@ namespace Memory
     }
 
     void * MemoryReserve(uint64_t size);
-    void * MemoryCommit(void * buf, size_t size);
+    void * MemoryCommit(void * buf, uint64_t size);
 }
 
 #if !defined(TRINITY_PLATFORM_WINDOWS)


### PR DESCRIPTION
 Fix argument of MemoryCommit() that is inconsistent within head and impl, which could cause build break on some platforms.