### PR TITLE
Trinity.Core: fix #44; fix #16; fix #19

### DIFF
--- a/src/Trinity.C/include/Trinity/IO/Path.h
+++ b/src/Trinity.C/include/Trinity/IO/Path.h
@@ -32,6 +32,7 @@ namespace Trinity
             static const char WindowsDirectorySeparator = '\\';
             static const char UnixDirectorySeparator = '/';
             static const char *DirectorySeparators = "/\\";
+            extern String g_AssemblyPath;
 
 #if defined(TRINITY_PLATFORM_WINDOWS)
             static const char DirectorySeparator = WindowsDirectorySeparator;
@@ -325,13 +326,16 @@ namespace Trinity
 
             inline String MyAssemblyPath()
             {
+                if (g_AssemblyPath != "") return g_AssemblyPath;
+
 #if defined(TRINITY_PLATFORM_WINDOWS)
                 Array<u16char> lpFilename(1024);
                 HMODULE        hmodule = GetModuleHandleW(L"Trinity.C.dll");
                 /* If Trinity.C.dll is absent, we default to the executing assembly (sending NULL into the API) */
                 GetModuleFileNameW(hmodule, lpFilename, static_cast<DWORD>(lpFilename.Length()));
                 lpFilename[lpFilename.Length() - 1] = 0;
-                return GetDirectoryName(GetFullPath(String::FromWcharArray(lpFilename, -1)));
+                g_AssemblyPath = GetDirectoryName(GetFullPath(String::FromWcharArray(lpFilename, -1)));
+                return g_AssemblyPath;
 #elif defined(TRINITY_PLATFORM_LINUX)
                 // XXX does not make sense if MyAssemblyPath always point to the mono host...
                 char* filename_buf    = new char[1024];
@@ -340,7 +344,8 @@ namespace Trinity
                 filename_buf[filename_buf_size] = 0;
                 String ret(filename_buf);
                 delete[] filename_buf;
-                return GetDirectoryName(ret);
+                g_AssemblyPath = GetDirectoryName(ret);
+                return g_AssemblyPath;
 #else
 #error Not supported
 #endif

--- a/src/Trinity.C/src/Runtime/init.cpp
+++ b/src/Trinity.C/src/Runtime/init.cpp
@@ -7,8 +7,19 @@
 #include "BackgroundThread/BackgroundThread.h"
 #include "Trinity/Diagnostics/LogAutoFlushTask.h"
 
+namespace Trinity
+{
+    namespace IO
+    {
+        namespace Path
+        {
+            Trinity::String g_AssemblyPath = "";
+        }
+    }
+}
+
 /* Should only be reached from CLR*/
-DLL_EXPORT VOID __stdcall __INIT_TRINITY_C__()
+DLL_EXPORT VOID __stdcall __INIT_TRINITY_C__(u16char* pAssemblyPath)
 {
 #ifdef TRINITY_PLATFORM_WINDOWS
     Memory::LargePageMinimum = GetLargePageMinimum();
@@ -22,6 +33,8 @@ DLL_EXPORT VOID __stdcall __INIT_TRINITY_C__()
 #ifdef TRINITY_OPTIONAL_PREEMPTIVE
     Runtime::__transition_enabled = true;
 #endif
+
+    Trinity::IO::Path::g_AssemblyPath = Trinity::String::FromWcharArray(pAssemblyPath, -1);
 
     BackgroundThread::TaskScheduler::Start();
 }

--- a/src/Trinity.Core/Trinity/Configuration/TrinityConfig.IO.cs
+++ b/src/Trinity.Core/Trinity/Configuration/TrinityConfig.IO.cs
@@ -114,13 +114,16 @@ namespace Trinity
                 }
                 catch (Exception) { }
             }
+            string dir = Path.GetDirectoryName(configFile);
+            if (dir == string.Empty) dir = Global.MyAssemblyPath;
+
             FileUtility.CompletePath(Path.GetDirectoryName(configFile), true);
             #region create basic xml info
             XmlDocument configXml = new XmlDocument();
             XmlDeclaration declaration = configXml.CreateXmlDeclaration("1.0", "utf-8", null);
             XmlNode rootNode = configXml.CreateElement(ConfigurationConstants.Tags.ROOT_NODE);
             XmlAttribute version = configXml.CreateAttribute(ConfigurationConstants.Attrs.CONFIG_VERSION);
-            version.Value = "1.0";
+            version.Value = ConfigurationConstants.Tags.CURRENTVER;
             rootNode.Attributes.Append(version);
             #endregion
             #region Get Local Setting Info

--- a/src/Trinity.Core/Trinity/Runtime/TrinityC.cs
+++ b/src/Trinity.Core/Trinity/Runtime/TrinityC.cs
@@ -27,7 +27,7 @@ namespace Trinity
         private static bool   s_initialized = false;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void Init()
+        internal unsafe static void Init()
         {
             lock (s_initlock)
             {
@@ -70,7 +70,10 @@ namespace Trinity
                 }
 
                 /* native assembly is released. initialize Trinity.C now */
-                __INIT_TRINITY_C__();
+                fixed(char* pAssemblyPath = AssemblyPath.MyAssemblyPath)
+                {
+                    __INIT_TRINITY_C__(pAssemblyPath);
+                }
 
                 if (Environment.OSVersion.Platform == PlatformID.Win32NT)
                 {
@@ -110,6 +113,6 @@ namespace Trinity
         }
 
         [DllImport(TrinityC.AssemblyName)]
-        private static extern unsafe void __INIT_TRINITY_C__();
+        private static extern unsafe void __INIT_TRINITY_C__(char* pAssemblyPath);
     }
 }

--- a/src/Trinity.Core/Utilities/IO/FileUtility.cs
+++ b/src/Trinity.Core/Utilities/IO/FileUtility.cs
@@ -81,7 +81,11 @@ namespace Trinity.Utilities
         /// <returns>The completed directory path.</returns>
         public static string CompletePath(string path, bool create_nonexistent = true)
         {
+            if (path == null) throw new ArgumentNullException("path");
+            if (path == "") path = Environment.CurrentDirectory;
+
             string _path = path;
+
             if (path[path.Length - 1] != Path.DirectorySeparatorChar)
                 _path = path + Path.DirectorySeparatorChar;
             if (create_nonexistent && (!Directory.Exists(_path)))

--- a/src/Trinity.Core/Utilities/MISC/AssemblyPath.cs
+++ b/src/Trinity.Core/Utilities/MISC/AssemblyPath.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -10,15 +11,71 @@ namespace Trinity.Utilities
 {
     internal static class AssemblyPath
     {
-        private static string my_assembly_path = "";
+        private static string my_assembly_path = null;
         internal static string MyAssemblyPath
         {
             get
             {
-                if (my_assembly_path.Length == 0)
+                if (my_assembly_path == null)
                 {
+                    //  primary heuristics: find the assembly that calls into Trinity
+                    Assembly trinity_asm = Assembly.GetExecutingAssembly();
+                    int firstTrinityFrame = 0;
+                    for (int skipFrames = 1; ; skipFrames++)
+                    {
+                        StackFrame stackFrame;
+                        try
+                        {
+                            stackFrame = new StackFrame(skipFrames);
+                            if (stackFrame.GetMethod() == null) break;
+                        }
+                        catch { break; }
+
+                        try
+                        {
+                            var asm = stackFrame.GetMethod().Module.Assembly;
+                            if (asm == trinity_asm) firstTrinityFrame = skipFrames;
+                        }
+                        catch { continue; }
+                    }
+
+                    for (int skipFrames = firstTrinityFrame + 1; ; skipFrames++)
+                    {
+                        StackFrame stackFrame;
+                        try
+                        {
+                            stackFrame = new StackFrame(skipFrames);
+                            if (stackFrame.GetMethod() == null) break;
+                        }
+                        catch { break; }
+
+                        try
+                        {
+                            var method = stackFrame.GetMethod();
+                            var type   = method.DeclaringType;
+                            var asm    = method.Module.Assembly;
+
+                            if (asm == trinity_asm) continue;
+                            if (asm.IsDynamic) continue;
+                            if (type == typeof(System.RuntimeMethodHandle)) continue;
+                            if (type.FullName == "System.Linq.Enumerable+WhereSelectEnumerableIterator`2") continue;
+                            if (type.FullName == "System.Linq.Enumerable+WhereEnumerableIterator`1") continue;
+                            if (type.FullName == "System.Linq.Enumerable") continue;
+
+                            var path = asm.Location;
+                            my_assembly_path = System.IO.Path.GetDirectoryName(path) + Path.DirectorySeparatorChar;
+                            break;
+                        }
+                        catch { continue; }
+                    }
+                }
+
+                if (my_assembly_path == null)
+                {
+                    //  last resort heuristic: return the path of the Trinity assembly.
                     my_assembly_path = System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + Path.DirectorySeparatorChar;
                 }
+
                 return my_assembly_path;
             }
         }


### PR DESCRIPTION
Various fixes on assembly path, config and FileUtility.
- The semantics of `Global.MyAssemblyPath` is changed from "get the directory of trinity core" to "get the directory of the user assembly" so multiple user programs safely use the assembly path without interference (they may share the same copy of trinity.core)
- The assembly path is passed to Trinity.C during initialization.