### PR TITLE
TrinityConfig: preserve hostname and port in ServerInfo, config secti…

### DIFF
--- a/src/Trinity.Core/Network/Instance/CommunicationInstance.cs
+++ b/src/Trinity.Core/Network/Instance/CommunicationInstance.cs
@@ -19,6 +19,7 @@ using System.Runtime.CompilerServices;
 using System.Globalization;
 using Trinity.Network.Messaging;
 using System.Diagnostics;
+using Trinity.Utilities;
 
 namespace Trinity.Network
 {
@@ -283,6 +284,10 @@ namespace Trinity.Network
                 {
                     Log.WriteLine(LogLevel.Debug, "Starting communication instance.");
                     var _config = TrinityConfig.CurrentClusterConfig;
+                    var _si = _config.GetMyServerInfo() ?? _config.GetMyProxyInfo();
+                    var _my_ip = Global.MyIPAddress;
+
+                    if (_si != null) _my_ip = NetworkUtility.Hostname2IPv4Address(_si.HostName);
 
                     _config.RunningMode = this.RunningMode;
                     Global.CommunicationInstance = this;
@@ -299,7 +304,7 @@ namespace Trinity.Network
 
                     //  Initialize message passing networking
                     NativeNetwork.StartTrinityServer((UInt16)_config.ListeningPort);
-                    Log.WriteLine("My IPEndPoint: " + _config.MyBoundIP + ":" + _config.ListeningPort);
+                    Log.WriteLine("My IPEndPoint: " + _my_ip + ":" + _config.ListeningPort);
 
                     //  Initialize cloud storage
                     memory_cloud = Global.CloudStorage;

--- a/src/Trinity.Core/Network/Messaging/MessageHandlerSet/DefaultSyncReqHandlerSet.cs
+++ b/src/Trinity.Core/Network/Messaging/MessageHandlerSet/DefaultSyncReqHandlerSet.cs
@@ -61,10 +61,11 @@ namespace Trinity.Network.Messaging
                     {
                         //IPAddress(4)+Port(4)
                         IPAddress aggregator_address = BitHelper.ToIPAddress(args.Buffer, args.Offset);
-                        IPEndPoint ipe = new IPEndPoint(aggregator_address, *(int*)(args.Buffer + args.Offset + 4));
+                        int aggregator_port = *(int*)(args.Buffer + args.Offset + 4);
+                        ServerInfo si = new ServerInfo(aggregator_address.ToString(), aggregator_port, "", LogLevel.Info);
                         lock (Global.ProxyTable)
                         {
-                            Global.ProxyTable[ipe] = new Storage.RemoteStorage(ipe, TrinityConfig.ClientMaxConn);
+                            Global.ProxyTable[si.EndPoint] = new Storage.RemoteStorage(si, TrinityConfig.ClientMaxConn);
                         }
                     }
                 });

--- a/src/Trinity.Core/Network/ServerInfo.cs
+++ b/src/Trinity.Core/Network/ServerInfo.cs
@@ -15,6 +15,9 @@ using Trinity.Utilities;
 using Trinity.Diagnostics;
 namespace Trinity.Network
 {
+    /// <summary>
+    /// Represent the configuration information of a server or proxy.
+    /// </summary>
     public class ServerInfo : ConfigurationSection
     {
         internal ServerInfo(XElement configSection)
@@ -24,18 +27,18 @@ namespace Trinity.Network
             string[] parts = endpoint.Split(new char[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
 
             HostName = parts[0].Trim();
-            EndPoint = NetworkUtility.Hostname2IPEndPoint(endpoint);
+            Port     = int.Parse(parts[1].Trim());
             AssemblyPath = configSection.Attribute(ConfigurationConstants.Attrs.ASSEMBLY_PATH) == null ? null : configSection.Attribute(ConfigurationConstants.Attrs.ASSEMBLY_PATH).Value;
             Id = configSection.Attribute(ConfigurationConstants.Attrs.AVAILABILITY_GROUP) == null ? null : configSection.Attribute(ConfigurationConstants.Attrs.AVAILABILITY_GROUP).Value;
         }
 
         //  For legacy code compatibility
-        private ServerInfo(string hostName, string assemblyPath, string availabilityGroup, IPEndPoint endpoint, string storageRoot, string loggingLevel)
+        private ServerInfo(string hostName, int port, string assemblyPath, string availabilityGroup, string storageRoot, string loggingLevel)
         {
             HostName = hostName;
             AssemblyPath = assemblyPath;
             Id = availabilityGroup;
-            EndPoint = endpoint;
+            Port = port;
 
             this.Add(ConfigurationConstants.Tags.STORAGE,
                 new ConfigurationEntry(ConfigurationConstants.Tags.STORAGE,
@@ -46,25 +49,14 @@ namespace Trinity.Network
                 new Dictionary<string, string> { { ConfigurationConstants.Attrs.LOGGING_LEVEL, loggingLevel } }));
         }
 
-        private ServerInfo(string hostName, int port, string assemblyPath, string storageRoot, string loggingLevel, string availabilityGroup)
-            : this(hostName,  assemblyPath, availabilityGroup, NetworkUtility.Hostname2IPEndPoint(hostName + ":" + port), storageRoot, loggingLevel) { }
-
         internal static ServerInfo _LegacyCreateServerInfo(string hostName, int port, string assemblyPath, string storageRoot, string loggingLevel, string availabilityGroup)
         {
             return new ServerInfo(hostName, port, assemblyPath, storageRoot, loggingLevel, availabilityGroup);
         }
 
-        internal static ServerInfo _LegacyCreateServerInfo(string hostName, string assemblyPath, string availabilityGroup, IPEndPoint endpoint, string storageRoot, string loggingLevel)
-        {
-            return new ServerInfo(hostName,  assemblyPath, availabilityGroup, endpoint, storageRoot, loggingLevel);
-        }
         /// <summary>
-        /// for legacy
+        /// Constructs a ServerInfo instance.
         /// </summary>
-        /// <param name="hostName"></param>
-        /// <param name="port"></param>
-        /// <param name="assemblyPath"></param>
-        /// <param name="logLevel"></param>
         public ServerInfo(string hostName, int port, string assemblyPath, LogLevel logLevel)
         {
             HostName = hostName;
@@ -75,27 +67,18 @@ namespace Trinity.Network
                 new Dictionary<string, string> { { ConfigurationConstants.Attrs.LOGGING_LEVEL, logLevel.ToString() } }));
         }
         /// <summary>
-        /// for legacy
+        /// Construct a ServerInfo instance.
         /// </summary>
-        /// <param name="hostName"></param>
-        /// <param name="port"></param>
-        /// <param name="assemblyPath"></param>
-        /// <param name="logLevel"></param>
-        public ServerInfo(string hostName, int port, LogLevel logLevel, string Id, string assemblyPath)
-            : this(hostName, assemblyPath, Id, NetworkUtility.Hostname2IPEndPoint(hostName + ":" + port), "", logLevel.ToString()) { }
-        /// <summary>
-        /// for legacy
-        /// </summary>
-        /// <param name="hostName"></param>
-        /// <param name="port"></param>
-        /// <param name="assemblyPath"></param>
-        /// <param name="logLevel"></param>
         public ServerInfo()
         { }
         /// <summary>
         /// The host name of the server.
         /// </summary>
         public string HostName { get; private set; }
+        /// <summary>
+        /// The port of the server.
+        /// </summary>
+        public int Port { get; private set; }
         /// <summary>
         /// The assembly path of the server.
         /// </summary>
@@ -107,6 +90,15 @@ namespace Trinity.Network
         /// <summary>
         /// The endpoint of the server.
         /// </summary>
-        public IPEndPoint EndPoint { get; private set; }
+        public IPEndPoint EndPoint
+        {
+            get
+            {
+                if (_ip_endpoint == null) _ip_endpoint = NetworkUtility.Hostname2IPEndPoint(HostName + ":" + Port.ToString());
+                return _ip_endpoint;
+            }
+        }
+
+        private IPEndPoint _ip_endpoint = null;
     }
 }

--- a/src/Trinity.Core/Storage/MemoryCloud/MemoryCloud.Message.cs
+++ b/src/Trinity.Core/Storage/MemoryCloud/MemoryCloud.Message.cs
@@ -82,7 +82,7 @@ namespace Trinity.Storage
                             {
                                 foreach (var instance in TrinityConfig.Proxies[i].Instances)
                                 {
-                                    new_proxy_list.Add(new RemoteStorage(instance.EndPoint, TrinityConfig.ClientMaxConn));
+                                    new_proxy_list.Add(new RemoteStorage(instance, TrinityConfig.ClientMaxConn));
                                 }
                             }
 

--- a/src/Trinity.Core/Trinity/Configuration/ClusterConfig.cs
+++ b/src/Trinity.Core/Trinity/Configuration/ClusterConfig.cs
@@ -36,7 +36,7 @@ namespace Trinity
             if (!File.Exists(xmlConfig))
                 return;
             xml_config = new XMLConfig(configFile);
-            LoadConfig();
+            _LegacyLoadConfig();
         }
 
         internal static ClusterConfig _LegacyLoadClusterConfig(string xmlConfig)
@@ -135,12 +135,9 @@ namespace Trinity
         {
             get
             {
-                return Servers
-                    .SelectMany(_ => _.Instances
-                        .Select(instance =>
-                            new IPEndPoint(
-                                instance.EndPoint.Address,
-                                instance.EndPoint.Port))).ToList();
+                return Servers.SelectMany(_ => _.Instances
+                        .Select(instance => instance.EndPoint))
+                        .ToList();
             }
         }
 
@@ -151,47 +148,9 @@ namespace Trinity
         {
             get
             {
-                return Proxies
-                    .SelectMany(_ => _.Instances
-                        .Select(instance =>
-                            new IPEndPoint(
-                                instance.EndPoint.Address,
-                                instance.EndPoint.Port))).ToList();
-            }
-        }
-
-        /// <summary>
-        /// Gets the Ip address of the current server in the cluster.
-        /// </summary>
-        internal IPAddress MyBoundIP
-        {
-            get
-            {
-                IPAddress my_ip_address;
-                if (RunningMode == RunningMode.Server)
-                {
-                    var instance = GetMyServerInfo();
-                    if (instance != null)
-                    {
-                        if (IPAddress.TryParse(instance.HostName, out my_ip_address))
-                        {
-                            return my_ip_address;
-                        }
-                    }
-                }
-
-                if (RunningMode == RunningMode.Proxy)
-                {
-                    var instance = GetMyProxyInfo();
-                    if (instance != null)
-                    {
-                        if (IPAddress.TryParse(instance.HostName, out my_ip_address))
-                        {
-                            return my_ip_address;
-                        }
-                    }
-                }
-                return Global.MyIPAddress;
+                return Proxies.SelectMany(_ => _.Instances
+                        .Select(instance => instance.EndPoint))
+                        .ToList();
             }
         }
 
@@ -224,8 +183,7 @@ namespace Trinity
                 var instance = GetMyServerInfo();
                 if (instance != null)
                 {
-                    Global.MyIPAddress = instance.EndPoint.Address;
-                    return instance.EndPoint.Port;
+                    return instance.Port;
                 }
                 return TrinityConfig.DefaultServerPort;
             }
@@ -241,8 +199,7 @@ namespace Trinity
                 var instance = GetMyProxyInfo();
                 if (instance != null)
                 {
-                    Global.MyIPAddress = instance.EndPoint.Address;
-                    return instance.EndPoint.Port;
+                    return instance.Port;
                 }
                 return TrinityConfig.DefaultProxyPort;
             }
@@ -328,8 +285,8 @@ namespace Trinity
                 {
                     if (instance.AssemblyPath != null)
                     {
-                        if (IPAddressComparer.CompareIPAddress(instance.EndPoint.Address, Global.MyIPAddress) == 0 &&
-                    FileUtility.CompletePath(instance.AssemblyPath, false).ToLowerInvariant().Equals(Global.MyAssemblyPath.ToLowerInvariant()))
+                        if (IPAddressComparer.IsLocalhost(instance.HostName) && 
+                            FileUtility.CompletePath(instance.AssemblyPath, false).ToLowerInvariant().Equals(Global.MyAssemblyPath.ToLowerInvariant()))
                         {
                             return instance;
                         }
@@ -340,7 +297,7 @@ namespace Trinity
             {
                 foreach (var instance in Servers[i].Instances)
                 {
-                    if (IPAddressComparer.CompareIPAddress(instance.EndPoint.Address, Global.MyIPAddress) == 0)
+                    if (IPAddressComparer.IsLocalhost(instance.HostName))
                         return instance;
                 }
             }
@@ -359,7 +316,7 @@ namespace Trinity
                 {
                     if (instance.AssemblyPath != null)
                     {
-                        if (IPAddressComparer.CompareIPAddress(instance.EndPoint.Address, Global.MyIPAddress) == 0 &&
+                        if (IPAddressComparer.IsLocalhost(instance.HostName) && 
                             FileUtility.CompletePath(instance.AssemblyPath, false).ToLowerInvariant().Equals(Global.MyAssemblyPath.ToLowerInvariant()))
                         {
                             return instance;
@@ -369,7 +326,7 @@ namespace Trinity
 
                 foreach (var instance in Proxies[i].Instances)
                 {
-                    if (IPAddressComparer.CompareIPAddress(instance.EndPoint.Address, Global.MyIPAddress) == 0)
+                    if (IPAddressComparer.IsLocalhost(instance.HostName))
                         return instance;
                 }
             }
@@ -394,7 +351,7 @@ namespace Trinity
             {
                 foreach (var instance in server.Instances)
                 {
-                    cw.WL("    {0}", instance.EndPoint);
+                    cw.WL("    {0}:{1}", instance.HostName, instance.Port);
                 }
             }
             #endregion
@@ -405,7 +362,7 @@ namespace Trinity
             {
                 foreach (var instance in proxy.Instances)
                 {
-                    cw.WL("    {0}", instance.EndPoint);
+                    cw.WL("    {0}:{1}", instance.HostName, instance.Port);
                 }
             }
             #endregion
@@ -415,16 +372,16 @@ namespace Trinity
             cw.WL();
             return cw.ToString();
         }
-       
-        private void LoadConfig()
+
+        private void _LegacyLoadConfig()
         {
             try
             {
                 Servers.Clear();
-                Servers.AddRange(GetAvailabilityGroupList(xml_config, "Servers", "Server", "ServerId"));
+                Servers.AddRange(_LegacyGetAvailabilityGroupList(xml_config, "Servers", "Server", "ServerId"));
 
                 Proxies.Clear();
-                Proxies.AddRange(GetAvailabilityGroupList(xml_config, "Proxies", "Proxy", "ProxyId"));
+                Proxies.AddRange(_LegacyGetAvailabilityGroupList(xml_config, "Proxies", "Proxy", "ProxyId"));
             }
             catch (Exception e)
             {
@@ -437,7 +394,7 @@ namespace Trinity
         /// <summary>
         /// Obtain a list of AvailabilityGroup from XML config.
         /// </summary>
-        private IEnumerable<AvailabilityGroup> GetAvailabilityGroupList(XMLConfig config, string xml_section_name, string xml_server_info_entry_name, string xml_agroup_id_attribute_name)
+        private IEnumerable<AvailabilityGroup> _LegacyGetAvailabilityGroupList(XMLConfig config, string xml_section_name, string xml_server_info_entry_name, string xml_agroup_id_attribute_name)
         {
             var server_entry_list = config.GetEntries(xml_section_name, xml_server_info_entry_name);
             Dictionary<string, List<ServerInfo>> id_infolist_dict = new Dictionary<string, List<ServerInfo>>();
@@ -445,55 +402,47 @@ namespace Trinity
             {
                 var str_ip_endpoint = server_entry_list[i].Value;
                 string[] parts = str_ip_endpoint.Split(new char[] { ':' });
-                IPEndPoint ep = Utilities.NetworkUtility.Hostname2IPEndPoint(str_ip_endpoint.Trim());
 
-                if (ep != null)
-                {
+                Dictionary<string, string> pvs = server_entry_list[i].Attributes().ToDictionary(attr => attr.Name.ToString(), attr => attr.Value);
 
-                    Dictionary<string, string> pvs = server_entry_list[i].Attributes().ToDictionary(attr => attr.Name.ToString(), attr => attr.Value);
+                string assemblyPath = null;
+                string Id = null;
+                LogLevel loggingLevel = LoggingConfig.c_DefaultLogLevel;
+                string storageRoot = null;
 
-                    string assemblyPath = null;
-                    string Id = null;
-                    LogLevel loggingLevel = LoggingConfig.c_DefaultLogLevel;
-                    string storageRoot = null;
+                if (pvs.ContainsKey(ConfigurationConstants.Attrs.ASSEMBLY_PATH))
+                    assemblyPath = FileUtility.CompletePath(pvs[ConfigurationConstants.Attrs.ASSEMBLY_PATH], false);
 
-                    if (pvs.ContainsKey(ConfigurationConstants.Attrs.ASSEMBLY_PATH))
-                        assemblyPath = FileUtility.CompletePath(pvs[ConfigurationConstants.Attrs.ASSEMBLY_PATH], false);
+                if (pvs.TryGetValue(ConfigurationConstants.Attrs.STORAGE_ROOT, out storageRoot))
+                    storageRoot = storageRoot.Trim();
 
-                    if (pvs.TryGetValue(ConfigurationConstants.Attrs.STORAGE_ROOT, out storageRoot))
-                        storageRoot = storageRoot.Trim();
+                if (pvs.ContainsKey(ConfigurationConstants.Attrs.LOGGING_LEVEL))
+                    loggingLevel = (LogLevel)Enum.Parse(typeof(LogLevel), pvs[ConfigurationConstants.Attrs.LOGGING_LEVEL], true);
 
-                    if (pvs.ContainsKey(ConfigurationConstants.Attrs.LOGGING_LEVEL))
-                        loggingLevel = (LogLevel)Enum.Parse(typeof(LogLevel), pvs[ConfigurationConstants.Attrs.LOGGING_LEVEL], true);
+                if (pvs.TryGetValue(xml_agroup_id_attribute_name, out Id))
+                    Id = Id.Trim();
+                else
+                    Id = i.ToString(CultureInfo.InvariantCulture);
 
-                    if (pvs.TryGetValue(xml_agroup_id_attribute_name, out Id))
-                        Id = Id.Trim();
-                    else
-                        Id = i.ToString(CultureInfo.InvariantCulture);
-
-                    ServerInfo si = ServerInfo._LegacyCreateServerInfo(
+                ServerInfo si = ServerInfo._LegacyCreateServerInfo(
                         hostName: parts[0].Trim(),
+                        port: int.Parse(parts[1]),
                         //httpPort: TrinityConfig.HttpPort,
                         assemblyPath: assemblyPath,
                         availabilityGroup: Id,
                         storageRoot: storageRoot,
-                        endpoint: ep,
                         loggingLevel: loggingLevel.ToString());
 
 
-                    List<ServerInfo> list = null;
-                    if (!id_infolist_dict.TryGetValue(si.Id, out list))
-                    {
-                        list = new List<ServerInfo>();
-                        id_infolist_dict.Add(si.Id, list);
-                    }
-                    list.Add(si);
-                }
-                else
+                List<ServerInfo> list = null;
+                if (!id_infolist_dict.TryGetValue(si.Id, out list))
                 {
-                    Log.WriteLine(LogLevel.Info, "Cannot resolve {0}, ignoring.", str_ip_endpoint);
+                    list = new List<ServerInfo>();
+                    id_infolist_dict.Add(si.Id, list);
                 }
+                list.Add(si);
             }
+
             return id_infolist_dict.Select(_ => new AvailabilityGroup(_.Key, _.Value.Select(si => (ServerInfo)si)));
         }
     }

--- a/src/Trinity.Core/Trinity/Configuration/ConfigurationEntries/LoggingConfig.cs
+++ b/src/Trinity.Core/Trinity/Configuration/ConfigurationEntries/LoggingConfig.cs
@@ -13,6 +13,9 @@ using Trinity.Utilities;
 
 namespace Trinity.Configuration
 {
+    /// <summary>
+    /// Contains settings for the configuration section "Storage".
+    /// </summary>
     public sealed class LoggingConfig
     {
         #region Singleton

--- a/src/Trinity.Core/Trinity/Configuration/ConfigurationEntries/NetworkConfig.cs
+++ b/src/Trinity.Core/Trinity/Configuration/ConfigurationEntries/NetworkConfig.cs
@@ -6,6 +6,9 @@ using System.Threading.Tasks;
 
 namespace Trinity.Configuration
 {
+    /// <summary>
+    /// Contains settings for the configuration section "Network".
+    /// </summary>
     public sealed class NetworkConfig
     {
         #region Singleton

--- a/src/Trinity.Core/Trinity/Configuration/ConfigurationEntries/StorageConfig.cs
+++ b/src/Trinity.Core/Trinity/Configuration/ConfigurationEntries/StorageConfig.cs
@@ -15,6 +15,9 @@ using Trinity.Utilities;
 
 namespace Trinity.Configuration
 {
+    /// <summary>
+    /// Contains settings for the configuration section "Storage".
+    /// </summary>
     public sealed class StorageConfig
     {
         #region Singleton

--- a/src/Trinity.Core/Trinity/Configuration/TrinityConfig.IO.cs
+++ b/src/Trinity.Core/Trinity/Configuration/TrinityConfig.IO.cs
@@ -134,11 +134,11 @@ namespace Trinity
 
             FileUtility.CompletePath(Path.GetDirectoryName(configFile), true);
             #region create basic xml info
-            XmlDocument configXml = new XmlDocument();
+            XmlDocument configXml      = new XmlDocument();
             XmlDeclaration declaration = configXml.CreateXmlDeclaration("1.0", "utf-8", null);
-            XmlNode rootNode = configXml.CreateElement(ConfigurationConstants.Tags.ROOT_NODE);
-            XmlAttribute version = configXml.CreateAttribute(ConfigurationConstants.Attrs.CONFIG_VERSION);
-            version.Value = ConfigurationConstants.Tags.CURRENTVER;
+            XmlNode rootNode           = configXml.CreateElement(ConfigurationConstants.Tags.ROOT_NODE);
+            XmlAttribute version       = configXml.CreateAttribute(ConfigurationConstants.Attrs.CONFIG_VERSION);
+            version.Value              = ConfigurationConstants.Tags.CURRENTVER;
             rootNode.Attributes.Append(version);
             #endregion
             #region Get Local Setting Info
@@ -168,7 +168,7 @@ namespace Trinity
                         foreach (var server in ag.Instances)
                         {
                             XmlNode serverNode = configXml.CreateElement(c_builtInSectionNames[i]);
-                            serverNode.Attributes.Append(SetAttribute(configXml, ConfigurationConstants.Attrs.ENDPOINT, server.EndPoint.ToString()));
+                            serverNode.Attributes.Append(SetAttribute(configXml, ConfigurationConstants.Attrs.ENDPOINT, String.Format("{0}:{1}", server.HostName, server.Port)));
                             if (server.AssemblyPath != null)
                                 serverNode.Attributes.Append(SetAttribute(configXml, ConfigurationConstants.Attrs.ASSEMBLY_PATH, server.AssemblyPath));
                             if (server.Id!=null)
@@ -218,7 +218,7 @@ namespace Trinity
         {
             LoadTrinityConfig(configFile, true);
         }
-        
+
         internal static void LoadTrinityConfig(bool forceLoad = false)
         {
             LoadTrinityConfig(DefaultConfigFile, forceLoad);
@@ -254,6 +254,7 @@ namespace Trinity
                         }
                     }
 
+                    // The default cluster config is the one without an Id.
                     s_current_cluster_config = new ClusterConfig(clusterSections.FirstOrDefault(
                         _ => _.Attribute(ConfigurationConstants.Attrs.ID) == null) ??
                             new XElement(ConfigurationConstants.Tags.CLUSTER));
@@ -291,7 +292,7 @@ namespace Trinity
         private static void LoadConfigLegacy(string trinity_config_file)
         {
             XMLConfig xml_config  = new XMLConfig(trinity_config_file);
-           
+
             //construct local configuration section  
             XElement localSection = new XElement(ConfigurationConstants.Tags.LOCAL);
             XElement loggingEntry = new XElement(ConfigurationConstants.Tags.LOGGING);
@@ -311,7 +312,7 @@ namespace Trinity
 
             //construct local ConfigurationSection
             s_localConfigurationSection = new ConfigurationSection(localSection);
-            
+
             //construct a clusterSections
             s_current_cluster_config = ClusterConfig._LegacyLoadClusterConfig(trinity_config_file);
 

--- a/src/Trinity.Core/Trinity/Configuration/TrinityConfig.cs
+++ b/src/Trinity.Core/Trinity/Configuration/TrinityConfig.cs
@@ -67,11 +67,14 @@ namespace Trinity
 
         /// <summary>
         /// Gets or sets the running mode of current Trinity process.
-        /// This property is obsolete and is kept for backward compatibility.
+        /// The setter of this property is obsolete and is kept for backward compatibility.
         /// Assigning a running mode to this property does not affect the system behavior.
         /// </summary>
-        [Obsolete("TrinityConfig.CurrentRunningMode is deprecated.")]
-        public static RunningMode CurrentRunningMode { get { return s_current_cluster_config.RunningMode; } set { s_current_cluster_config.RunningMode = value; } }
+        public static RunningMode CurrentRunningMode
+        {
+            get { return s_current_cluster_config.RunningMode; }
+            set { s_current_cluster_config.RunningMode = value; }
+        }
 
         /// <summary>
         /// Current system logging logLevel, default is LogLevel.Info.
@@ -90,7 +93,7 @@ namespace Trinity
             get { return LoggingConfig.Instance.LogDirectory; }
             set { LoggingConfig.Instance.LogDirectory = value; }
         }
-        
+
         /// <summary>
         /// Gets and Sets the bool value to represent whether to echo log entry on the standard output.
         /// </summary>
@@ -120,12 +123,13 @@ namespace Trinity
                     Servers.Clear();
                     Proxies.Clear();
 
-                    ServerInfo server = ServerInfo._LegacyCreateServerInfo("127.0.0.1",
-                        TrinityConfig.CurrentClusterConfig.ServerPort,
-                        AssemblyPath.MyAssemblyPath,
-                        AssemblyPath.MyAssemblyPath + "storage\\",
-                        LogLevel.Debug.ToString(),
-                        "0");
+                    ServerInfo server = ServerInfo._LegacyCreateServerInfo(
+                        hostName: "127.0.0.1",
+                        port: TrinityConfig.CurrentClusterConfig.ServerPort,
+                        assemblyPath: AssemblyPath.MyAssemblyPath,
+                        storageRoot: AssemblyPath.MyAssemblyPath + "storage\\",
+                        loggingLevel: LogLevel.Debug.ToString(),
+                        availabilityGroup: "0");
 
                     switch (CurrentClusterConfig.RunningMode)
                     {


### PR DESCRIPTION
…ons and RemoteStorage.

The IPEndPoint for a comm. instance is only resolved during connection, and failure to resolve results in failure to connect, rather than a failure in an earlier stage (config entry read/write etc.)