### PR TITLE
Misc: fix nunit tools for .net core

### DIFF
--- a/tests/nunit_tools/nunit_meta_runner/CommandLineOptions.cs
+++ b/tests/nunit_tools/nunit_meta_runner/CommandLineOptions.cs
@@ -1,5 +1,4 @@
 ﻿using CommandLine;
-using CommandLine.Text;
 
 namespace NUnitMetaRunner
 {
@@ -9,7 +8,7 @@ namespace NUnitMetaRunner
             HelpText = "The path to the runner for the test assembly.")]
         public string RunnerPath { get; set; }
 
-        [Option('t', "timeout", Required = false, DefaultValue = -1,
+        [Option('t', "timeout", Required = false, Default = -1,
             HelpText = "Set timeout for each test case in milliseconds.")]
         public int Timeout { get; set; }
 
@@ -21,19 +20,12 @@ namespace NUnitMetaRunner
             HelpText = "The path to the test assembly.")]
         public string AssemblyPath { get; set; }
 
-        [Option('o', "options", Required = false, DefaultValue = "",
+        [Option('o', "options", Required = false, Default = "",
             HelpText = "The command line arguments to be passed to the runner.")]
         public string RunnerOptions { get; set; }
 
         [Option('s', "seed", Required = false,
             HelpText = "The random seed to use for the tests.")]
         public int? RandomSeed { get; set; }
-
-        [HelpOption]
-        public string GetUsage()
-        {
-            return HelpText.AutoBuild(this,
-                (HelpText current) => HelpText.DefaultParsingErrorsHandler(this, current));
-        }
     }
 }

--- a/tests/nunit_tools/nunit_meta_runner/Program.cs
+++ b/tests/nunit_tools/nunit_meta_runner/Program.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using System.Xml;
 using System.Xml.Linq;
 using CommandLine;
-using CommandLine.Text;
 using NUnitLite;
 using NUnit.Framework.Api;
 using NUnit.Framework.Interfaces;
@@ -28,12 +27,13 @@ namespace NUnitMetaRunner
     {
         public static int Main(string[] args)
         {
-            var options = new CommandLineOptions();
-            if (!CommandLine.Parser.Default.ParseArguments(args, options))
-            {
-                return 1;
-            }
+            return CommandLine.Parser.Default.ParseArguments<CommandLineOptions>(args)
+                    .MapResult(options => MainCore(options),
+                               _ => 1);
+        }
 
+        private static int MainCore(CommandLineOptions options)
+        {
             var runnerPath = Path.GetFullPath(options.RunnerPath);
             var resultDirRoot = Path.GetFullPath(options.ResultDirPath);
             var assemblyPath = Path.GetFullPath(options.AssemblyPath);

--- a/tests/nunit_tools/nunit_meta_runner/nunit_meta_runner.csproj
+++ b/tests/nunit_tools/nunit_meta_runner/nunit_meta_runner.csproj
@@ -36,8 +36,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CommandLine, Version=1.9.71.2, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\CommandLineParser.1.9.71\lib\net45\CommandLine.dll</HintPath>
+    <Reference Include="CommandLine, Version=2.0.275.0, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CommandLineParser.2.1.1-beta\lib\net45\CommandLine.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/tests/nunit_tools/nunit_meta_runner/nunit_meta_runner_coreclr.csproj
+++ b/tests/nunit_tools/nunit_meta_runner/nunit_meta_runner_coreclr.csproj
@@ -2,9 +2,10 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <RuntimeFrameworkVersion>2.0.0-beta-001509-00</RuntimeFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="1.9.71" />
+    <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
     <PackageReference Include="GraphEngine.CoreCLR" Version="1.0.8850" />
     <PackageReference Include="NUnit" Version="3.6.1" />
     <PackageReference Include="NUnitLite" Version="3.6.1" />

--- a/tests/nunit_tools/nunit_meta_runner/packages.config
+++ b/tests/nunit_tools/nunit_meta_runner/packages.config
@@ -4,6 +4,6 @@
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
   <package id="NUnit" version="3.6.1" targetFramework="net461" />
   <package id="NUnitLite" version="3.6.1" targetFramework="net461" />
-  <package id="CommandLineParser" version="1.9.71" targetFramework="net461" />
+  <package id="CommandLineParser" version="2.1.1-beta" targetFramework="net461" />
 </packages>
 

--- a/tests/nunit_tools/nunit_test_runner/nunitlite-runner_coreclr.csproj
+++ b/tests/nunit_tools/nunit_test_runner/nunitlite-runner_coreclr.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <RuntimeFrameworkVersion>2.0.0-beta-001509-00</RuntimeFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="graphengine.coreclr" Version="1.0.8850" />


### PR DESCRIPTION
Because of an update of .NET Core, the meta runner and the test runner had once failed building. Now the problem is fixed.

However, misfortunes did not come singly. The stable version of `CommandLineParser`, one of the dependencies of the meta runner has dropped support for .NET Core 2.0. To cope with that, we now adopt the prerelease version of that library.

This PR fix both issues.