### PR TITLE
Added missing port assignment in legacy constructor

### DIFF
--- a/src/Trinity.Core/Network/ServerInfo.cs
+++ b/src/Trinity.Core/Network/ServerInfo.cs
@@ -61,6 +61,7 @@ namespace Trinity.Network
         {
             HostName = hostName;
             AssemblyPath = assemblyPath;
+	        Port = port;
 
             this.Add(ConfigurationConstants.Tags.LOGGING,
                 new ConfigurationEntry(ConfigurationConstants.Tags.LOGGING,


### PR DESCRIPTION
The (legacy )constructor is missing the assignment for port parameter.