### PR TITLE
Add a missed function in freebase example

### DIFF
--- a/samples/freebase-likq/freebase-likq/FreebaseAdapter.cs
+++ b/samples/freebase-likq/freebase-likq/FreebaseAdapter.cs
@@ -624,6 +624,11 @@ namespace freebase_likq
             throw new NotImplementedException();
         }
 
+        public ICell Deserialize()
+        {
+            throw new NotImplementedException();
+        }
+
         public ResizeFunctionDelegate ResizeFunction
         {
             get


### PR DESCRIPTION
This function is missed in FreebaseAdapter.cs when implementing IFanoutSearchCellAccessor