### PR TITLE
fix cellid property name and netcoreapp2.0 switch

### DIFF
--- a/src/Modules/LIKQ/FanoutSearch.UnitTest/LIKQTest.cs
+++ b/src/Modules/LIKQ/FanoutSearch.UnitTest/LIKQTest.cs
@@ -78,7 +78,7 @@ namespace FanoutSearch.UnitTest
         [Fact]
         public void Test4()
         {
-            var paths = KnowledgeGraph.StartFrom(123).VisitNode(_ => _.return_if(_.CellId == 123)).ToList();
+            var paths = KnowledgeGraph.StartFrom(123).VisitNode(_ => _.return_if(_.CellID == 123)).ToList();
         }
 
         [Fact]

--- a/src/Modules/LIKQ/FanoutSearch/FanoutSearch.csproj
+++ b/src/Modules/LIKQ/FanoutSearch/FanoutSearch.csproj
@@ -21,7 +21,7 @@
     <OutputPath>..\..\..\..\bin</OutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0' OR '$(TargetFramework)'=='netcoreapp2.0'">
     <DefineConstants>NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
 

--- a/src/Modules/LIKQ/FanoutSearch/QueryLanguage/Verbs.cs
+++ b/src/Modules/LIKQ/FanoutSearch/QueryLanguage/Verbs.cs
@@ -35,7 +35,7 @@ namespace FanoutSearch
 
         public static bool has_cell_id(this ICell cell, params long[] cellIds)
         {
-            return cellIds.Contains(cell.CellId);
+            return cellIds.Contains(cell.CellID);
         }
 
         public static bool type(this ICell cell, string type_name)


### PR DESCRIPTION
@yatli i just have a try, we do need the netcoreapp2.0 switch for ‘DefineConstants', since if build unittest with 'dotnet' command, we have to pass TargetFramework=netcoreapp2.0, then lost the 'NETSTANDARD2_0' definition, this will cause build error for FanoutSearch project.