### PR TITLE
Trinity.FFI.Metagen:  refactor how data is accessed 

### DIFF
--- a/src/Modules/Trinity.FFI/Trinity.FFI.Metagen.UnitTests/tsl/def.tsl
+++ b/src/Modules/Trinity.FFI/Trinity.FFI.Metagen.UnitTests/tsl/def.tsl
@@ -1,3 +1,11 @@
-﻿cell C1{
+﻿cell C1
+{
 	int foo;
+	string bar;
+}
+
+cell C2
+{
+    List<int> lst;
+	string bar;
 }

--- a/src/Modules/Trinity.FFI/Trinity.FFI.Metagen/CodeGen.fs
+++ b/src/Modules/Trinity.FFI/Trinity.FFI.Metagen/CodeGen.fs
@@ -127,8 +127,8 @@ module CodeGen =
                 PString.format template
                                [
                                 "moduleName" ->> moduleName
-                                "source"     ->> (srcs  |> PString.str'concatBy "\n" )
-                                "decl"       ->> (decls |> PString.str'concatBy "\n")
+                                "source"     ->> (srcs       |> PString.str'concatBy "\n" )
+                                "decl"       ->> (decls      |> PString.str'concatBy "\n")
                                 "use_newobj" ->> (use_newobj |> PString.str'concatBy "\n")
                                ]
     

--- a/src/Modules/Trinity.FFI/Trinity.FFI.Metagen/CodeGen.fs
+++ b/src/Modules/Trinity.FFI/Trinity.FFI.Metagen/CodeGen.fs
@@ -66,12 +66,13 @@ module CodeGen =
             | (subject: TypeDescriptor, fields: seq<FunctionDescriptor*(FunctionDecl * (FunctionId -> Code))>) :: tail ->
 
                 let (defs, srcs) = fields |> Seq.map (fun (toCompile, (fnDecl, codeMaker)) -> 
-                                                let concrete_verb = 
-                                                    match toCompile.Verb with
-                                                    | SGet x -> ComposedVerb(SGet x, BGet)
-                                                    | SSet x -> ComposedVerb(SSet x, BSet)
-                                                    | x      -> x
-                                                sprintf "0x%xll" (CompileFunction({ toCompile with Verb = concrete_verb }).CallSite.ToInt64())
+                                                //let concrete_verb = 
+                                                //    match toCompile.Verb with
+                                                //    | SGet x -> ComposedVerb(SGet x, BGet)
+                                                //    | SSet x -> ComposedVerb(SSet x, BSet)
+                                                //    | x      -> x
+
+                                                sprintf "0x%xll" ((CompileFunction toCompile).CallSite.ToInt64())
                                                 |> codeMaker
                                                 |> fun it -> (fnDecl, it))
                                        |> List.ofSeq

--- a/src/Modules/Trinity.FFI/Trinity.FFI.Metagen/CommonForRender.fs
+++ b/src/Modules/Trinity.FFI/Trinity.FFI.Metagen/CommonForRender.fs
@@ -26,6 +26,7 @@ module CommonForRender =
             subject |> getElemTypeFromSubject  
         else
             match verb with
+            | ComposedVerb (SGet fieldName, BGet)
             | SGet fieldName
             | SSet fieldName ->
                 subject |> getMemberTypeFromSubject fieldName

--- a/src/Modules/Trinity.FFI/Trinity.FFI.Metagen/MetaGen.fs
+++ b/src/Modules/Trinity.FFI/Trinity.FFI.Metagen/MetaGen.fs
@@ -48,8 +48,9 @@ module MetaGen =
                     let fieldName   = member'.Name
                     SGet fieldName
                     |> fun it -> if isPrimitive member'.Type.TypeCode then ComposedVerb(it, BGet) else it
-                    |> fun it -> it::[SSet fieldName; BGet; BSet]
+                    |> fun it -> [it; SSet fieldName;]
                     |> Seq.map (render type'))
+           |> fun tail -> [BGet; BSet] |> Seq.map (render type') |> Seq.append tail 
            
         
         | {TypeCode=LIST;ElementType=elemTypes}  ->

--- a/src/Modules/Trinity.FFI/Trinity.FFI.Metagen/MetaGen.fs
+++ b/src/Modules/Trinity.FFI/Trinity.FFI.Metagen/MetaGen.fs
@@ -50,19 +50,18 @@ module MetaGen =
                     |> fun it -> if isPrimitive member'.Type.TypeCode then ComposedVerb(it, BGet) else it
                     |> fun it -> [it; SSet fieldName;]
                     |> Seq.map (render type'))
-           |> fun tail -> [BGet; BSet] |> Seq.map (render type') |> Seq.append tail 
-           
         
         | {TypeCode=LIST;ElementType=elemTypes}  ->
              LGet
              |> fun it -> if (elemTypes |> Seq.head |> fun x -> isPrimitive x.TypeCode) then ComposedVerb (it, BGet) else it
              |> fun it -> it::[LSet; LContains; LCount;] 
              |>  Seq.map (render type')
-                
 
         | _                                      ->
              (** primitive type **)
              raise (NotImplementedException())
+
+        |> fun tail -> [BGet; BSet] |> Seq.map (render type') |> Seq.append tail 
     
     let rec TypeInfer(anyType: TypeDescriptor): seq<TypeDescriptor> = 
     (** inference out the descriptors of struct types and generic list types in a cell descriptor.**)

--- a/src/Modules/Trinity.FFI/Trinity.FFI.Metagen/SwigGen.fs
+++ b/src/Modules/Trinity.FFI/Trinity.FFI.Metagen/SwigGen.fs
@@ -24,14 +24,14 @@ module SwigGen =
         match typeDesc.TypeCode with
         | NULL     -> "void"
         
-        | U8  -> "uint8_t"
-        | U16 -> "uint16_t"
-        | U32 -> "uint32_t"
-        | U64 -> "uint64_t"
-        | I8  -> "int8_t"
-        | I16 -> "int16_t"
-        | I32 -> "int32_t"
-        | I64 -> "int64_t"
+        | U8       -> "uint8_t"
+        | U16      -> "uint16_t"
+        | U32      -> "uint32_t"
+        | U64      -> "uint64_t"
+        | I8       -> "int8_t"
+        | I16      -> "int16_t"
+        | I32      -> "int32_t"
+        | I64      -> "int64_t"
         
         | F32      -> "float"
         | F64      -> "double"
@@ -52,18 +52,25 @@ module SwigGen =
                : FunctionDecl * (FunctionId -> Code) =
         
         let mutable decl: string = null
-         
+        
         let subject'name = name'maker manglingCode subject
         
-        let object = getObjectFromSubjectAndVerb subject verb
-
-        let object'type  = swig'typestr'mapper object 
+        let object'type  = 
+            match verb with
+            | BSet
+            | BGet -> swig'typestr'mapper subject
+            | _    -> swig'typestr'mapper (getObjectFromSubjectAndVerb subject verb) 
 
         let TemplateArgs = ["object type" ->> object'type; "subject name" ->> subject'name; "_" ->> manglingCode]
 
-
+        
         let render'filter = fun (lst: list<char>) -> lst.Head <> '!'
         match verb with
+        | BGet ->
+            decl <- "static {object type} Get{_}{subject name}(void *);"
+            "
+            
+            "
         | LGet -> 
             decl <- PString.format "static {object type} {subject name}{_}Get(void* subject, int idx);" TemplateArgs 
             "

--- a/src/Modules/Trinity.FFI/Trinity.FFI.Metagen/SwigGen.fs
+++ b/src/Modules/Trinity.FFI/Trinity.FFI.Metagen/SwigGen.fs
@@ -58,7 +58,7 @@ module SwigGen =
         let object'type  = 
             match verb with
             | BSet
-            | BGet -> null
+            | BGet -> String.Empty
             | _    -> swig'typestr'mapper (getObjectFromSubjectAndVerb subject verb) 
 
         let TemplateArgs = ["object type" ->> object'type; "subject name" ->> subject'name; "_" ->> manglingCode]

--- a/src/Modules/Trinity.FFI/Trinity.FFI.Metagen/SwigGen.fs
+++ b/src/Modules/Trinity.FFI/Trinity.FFI.Metagen/SwigGen.fs
@@ -70,68 +70,68 @@ module SwigGen =
         | BGet ->
             decl <- "static void* Get{_}{subject name}(void *);"
             
-            "static void* (* {_}Get{_}{subject name})(void*) = (void* (*)(void*)){!fn addr};" +
-            "static void* Get{_}{subject name}(void *subject)" + 
-            "{{" +
-            "       return {_}Get{subject name}(subject);" + 
+            "static void* (* {_}Get{_}{subject name})(void*) = (void* (*)(void*)){!fn addr};" +/
+            "static void* Get{_}{subject name}(void *subject)" +/
+            "{{" +/
+            "       return {_}Get{_}{subject name}(subject);" +/ 
             "}}"
         
         | BSet ->
             decl <- "static void Set{_}{subject name}(void*, void*);"
 
-            "static void (* {_}Set{_}{subject name}(void*, void*) = (void (*)(void*, void*)){!fn addr};" +
-            "static void Set{_}{subject name}(void* subject, void* object)" + 
-            "{{" + 
-            "       return {_}Set{_}{subject name}(subject, object);" +
+            "static void (* {_}Set{_}{subject name})(void*, void*) = (void (*)(void*, void*)){!fn addr};" +/
+            "static void Set{_}{subject name}(void* subject, void* object)" +/ 
+            "{{" +/ 
+            "       return {_}Set{_}{subject name}(subject, object);" +/
             "}}"
 
         | ComposedVerb (LGet, BGet)
         | LGet -> 
             decl <- PString.format "static {object type} {subject name}{_}Get(void*, int);" TemplateArgs 
             
-            "static {object type} (* {_}{subject name}{_}Get)(void*, int) =  ({object type} (*)(void*, int)){!fn addr};" +
-            "static {object type} {subject name}{_}Get(void* subject, int idx)" + 
-            "{{" +
-            "        return {_}{subject name}{_}Get(subject, idx);" +
+            "static {object type} (* {_}{subject name}{_}Get)(void*, int) =  ({object type} (*)(void*, int)){!fn addr};" +/
+            "static {object type} {subject name}{_}Get(void* subject, int idx)" +/ 
+            "{{" +/
+            "        return {_}{subject name}{_}Get(subject, idx);" +/
             "}}"
             
         
         | LSet ->
             decl <- PString.format "static void {subject name}{_}Set(void*, int, {object type});" TemplateArgs
-            "static void (* {_}{subject name}{_}Set)(void*, int,  {object type}) = (void (*)(void*, int, {object type} object)){!fn addr};" +
-            "static void {subject name}{_}Set(void* subject, int idx, {object type} object)" +
-            "{{" + 
-            "return {_}{subject name}{_}Set(subject, idx, object);" + 
+            "static void (* {_}{subject name}{_}Set)(void*, int,  {object type}) = (void (*)(void*, int, {object type} object)){!fn addr};" +/
+            "static void {subject name}{_}Set(void* subject, int idx, {object type} object)" +/
+            "{{" +/ 
+            "return {_}{subject name}{_}Set(subject, idx, object);" +/ 
             "}}"
             
 
         | LCount ->
             decl <- PString.format "static int Count{_}{subject name}(void* subject);" TemplateArgs;
             
-            "static int (* {_}Count{_}{subject name})(void*) = (int (*)(void* )) {!fn addr};" +
-            "static int Count{_}{subject name}(void* subject)" +
-            "{{" +
-            "    return {_}Count{_}{subject name}(subject);"+
+            "static int (* {_}Count{_}{subject name})(void*) = (int (*)(void* )) {!fn addr};" +/
+            "static int Count{_}{subject name}(void* subject)" +/
+            "{{" +/
+            "    return {_}Count{_}{subject name}(subject);"+/
             "}}"
 
         | LContains ->
 
             decl <- PString.format "static bool Contains{_}{subject name}(void*, {object type});" TemplateArgs;
             
-            "static bool (* {_}Contains{_}{subject name})(void*, {object type}) = (bool (*)(void*, {object type})) {!fn addr};" +
-            "static bool Contains{_}{subject name}(void* subject, {object type} object)" +
-            "{{" +
-            "    return {_}Contains{_}{subject name}(subject, object);" +
+            "static bool (* {_}Contains{_}{subject name})(void*, {object type}) = (bool (*)(void*, {object type})) {!fn addr};" +/
+            "static bool Contains{_}{subject name}(void* subject, {object type} object)" +/
+            "{{" +/
+            "    return {_}Contains{_}{subject name}(subject, object);" +/
             "}}"
         
         | ComposedVerb (SGet fieldName, BGet)
         | SGet fieldName ->
             let fnName = sprintf "{subject name}{_}Get{_}%s" fieldName
             decl <- PString.format "static {object type} {fnName}(void*);"  ("fnName" ->> fnName ::TemplateArgs);
-            "static {object type} (* {_}{:fnName})(void*) = ({object type} (*)(void*)){!fn addr};" + 
-            "static {object type} {:fnName}(void* subject)" +
-            "{{" +
-            "    return {_}{:fnName}(subject);" +
+            "static {object type} (* {_}{:fnName})(void*) = ({object type} (*)(void*)){!fn addr};" +/
+            "static {object type} {:fnName}(void* subject)" +/
+            "{{" +/
+            "    return {_}{:fnName}(subject);" +/
             "}}"
             
             |> fun template -> PString.format'cond (fun lst -> lst.Head = ':') template [":fnName" ->> fnName]
@@ -140,10 +140,10 @@ module SwigGen =
             let fnName = sprintf "{subject name}{_}Set{_}%s" fieldName
             decl <- PString.format "static void {fnName}(void*, {object type});" ("fnName" ->> fnName ::TemplateArgs);
 
-            "static void (* {_}{:fnName})(void*, {object type}) = (void (*)(void*, {object type})){!fn addr};" + 
-            "static void {:fnName}(void* subject, {object type} object)" +
-            "{{" +
-            "    return {_}{:fnName}(subject, object);" +
+            "static void (* {_}{:fnName})(void*, {object type}) = (void (*)(void*, {object type})){!fn addr};" +/ 
+            "static void {:fnName}(void* subject, {object type} object)" +/
+            "{{" +/
+            "    return {_}{:fnName}(subject, object);" +/
             "}}"
 
             |> fun template -> PString.format'cond (fun lst -> lst.Head = ':') template [":fnName" ->> fnName]

--- a/src/Modules/Trinity.FFI/Trinity.FFI.Metagen/Utils.fs
+++ b/src/Modules/Trinity.FFI/Trinity.FFI.Metagen/Utils.fs
@@ -8,6 +8,7 @@ module Operator =
     let (>>>) (head: 'T) (tail: seq<'T>) =  Seq.append (head |> Seq.singleton) tail
     let (<^.^^>) (left: 'T) (right: 'G) = (left, right)
     let (<^^.^>) (right: 'T) (left: 'G) = (left, right)
+    let inline (+/) (left: string) (right: string) = left + "\n" + right
 
 module PString = 
     (** python like string utilities **)

--- a/src/Modules/Trinity.FFI/Trinity.FFI.Python/Graph/jit.py
+++ b/src/Modules/Trinity.FFI/Trinity.FFI.Python/Graph/jit.py
@@ -1,4 +1,5 @@
 from .utils import Record
+import types
 
 
 # @binding(_TypeDescriptor)

--- a/src/Modules/Trinity.FFI/Trinity.FFI.Python/Graph/tsl.py
+++ b/src/Modules/Trinity.FFI/Trinity.FFI.Python/Graph/tsl.py
@@ -1,14 +1,18 @@
-from typing import NamedTuple, Tuple, List, Any, Callable
+from typing import NamedTuple, Tuple, List, Any, Callable, Dict
+import typing
 from abc import ABC, abstractmethod
 from Redy.Magic.Pattern import Pattern
 from Redy.Collections import Flow, Traversal
+from Redy.Tools.TypeInterface import Module
 
 
-class TSLSpec: ...
+class TSLSpec:
+    name: str
 
 
 class TSLObject(ABC):
-    tsl_spec: TSLSpec
+    spec: TSLSpec
+    __accessor__: object
 
 
 class TSLCell(TSLObject):
@@ -16,6 +20,10 @@ class TSLCell(TSLObject):
 
 
 class TSLStruct(TSLObject):
+    pass
+
+
+class TSLList(TSLObject):
     pass
 
 
@@ -29,7 +37,7 @@ class TslFieldSpec(TSLSpec, NamedTuple):
 
 class TSLStructSpec(TSLSpec, NamedTuple):
     name: str
-    fields: Tuple[TslFieldSpec]
+    fields: Tuple[TslFieldSpec, ...]
 
     def __str__(self):
         n = '\n'
@@ -54,14 +62,15 @@ class TSL:
     >>>     c: float
 
     >>> print(tsl.tsl_definitions)
-
+    take care that you couldn't use a field named `spec`
     """
 
     def __init__(self):
-        self.tsl_definitions: 'List[TSLObject]' = []
+        self.tsl_definitions: 'Dict[str, TSLObject]' = {}
+        self.module = None
+        self._total_type_names = set()  # typenames of all types manipulated in current tsl module.
 
     def cell(self, cls: type):
-
         __annotations__ = cls.__annotations__
 
         def _():
@@ -69,14 +78,17 @@ class TSL:
                 tsl_typename = tsl_typename_map(py_type)
                 yield TslFieldSpec(field_name, tsl_typename)
 
-        new_cls = type(cls.__name__, (TSLCell, *cls.__bases__), dict(cls.__dict__))
-        new_cls.tsl_spec = TSLCellSpec(cls.__name__, tuple(_()))
-        self.tsl_definitions.append(new_cls)
+        new_cls: TSLObject = type(cls.__name__,
+                                  (TSLCell, *cls.__bases__),
+                                  dict(cls.__dict__, __slots__=['__accessor__']))
+
+        new_cls.spec = TSLCellSpec(cls.__name__, tuple(_()))
+
+        self.tsl_definitions[new_cls.__name__] = new_cls
+
         return new_cls
 
     def struct(self, cls: type):
-        # noinspection PyDecorator
-
         __annotations__ = cls.__annotations__
 
         def _():
@@ -84,14 +96,78 @@ class TSL:
                 tsl_typename = tsl_typename_map(py_type)
                 yield TslFieldSpec(field_name, tsl_typename)
 
-        new_cls = type(cls.__name__, (TSLStruct, *cls.__bases__), dict(cls.__dict__))
-        new_cls.tsl_spec = TSLStructSpec(cls.__name__, tuple(_()))
-        self.tsl_definitions.append(new_cls)
+        new_cls: TSLObject = type(cls.__name__,
+                                  (TSLStruct, *cls.__bases__),
+                                  dict(cls.__dict__, __slots__=['__accessor__'])
+                                  )
+
+        new_cls.spec = TSLStructSpec(cls.__name__, tuple(_()))
+
+        self.tsl_definitions[new_cls.__name__] = new_cls
+
         return new_cls
 
+    def _jit(self) -> 'Module':
+        raise NotImplemented
 
-@Pattern
+    def jit(self) -> None:
+        self.module = module = self._jit()
+        for typename, each_type in self.tsl_definitions.items():
+            binding_methods_from_module_to_class(class_definition=each_type, module=module)
+
+
+def binding_methods_from_module_to_class(class_definition: typing.Union[TSLStruct], module: Module):
+    class_name = class_definition.__name__
+
+    class_definition.__init__ = get_init_fn(module, class_name)
+
+    struct_spec: typing.Union[TSLStructSpec, TSLCellSpec] = class_definition.spec
+
+    for each in struct_spec.fields:
+        _setter, _getter = get_setter_getter_fn(module, each.name)
+
+        if is_primitive(each.typename):
+            @property
+            def getter(self: TSLObject) -> each.typename:
+                return _getter(self.__accessor__)
+        else:
+
+            # if this field is not of primitive type, the return of `Jit` is of type `void *`,
+            # so wrap it as an object to represent.
+            object_wrapper = get_wrapper(each.typename)
+
+            @property
+            def getter(self: TSLObject) -> each.typename:
+                return object_wrapper(_getter(self.__accessor__))
+
+        @getter.setter
+        def setter(self: TSLObject, value: each.typename):
+            _setter(self.__accessor__, value)
+
+        setattr(class_definition, each.name, setter)
+
+
 def tsl_typename_map(py_type: type):
+    """
+    you can completely use python type objects to define a tsl cell/struct.
+        a: List[int]
+    and you can also use tsl grammar by typing with a string.
+        a: 'List<int>'
+    what's more, you can even mix them up:
+        a: List['int']
+
+    however, do not mix them up in one string:
+        a: 'List<int>'
+    >>> tsl = TSL()
+    >>>
+    >>> @tsl.cell
+    >>> class S:
+    >>>    a: List['S']
+    >>>    b: 'List<string>'
+    >>>    c: List[int]
+    >>> print([each.spec for each in tsl.tsl_definitions.values()])
+
+    """
     return py_type
 
 
@@ -125,6 +201,11 @@ def tsl_typename_map(typ: type):
     if isinstance(typ, str):
         return typ
 
+    # noinspection PyUnresolvedReferences
+    if isinstance(typ, typing._ForwardRef):
+        # noinspection PyUnresolvedReferences
+        return tsl_typename_map(typ.__forward_arg__)
+
     if isinstance(typ, (TSLCell, TSLStruct)):
         return typ.__name__
 
@@ -135,6 +216,7 @@ def tsl_typename_map(typ: type):
         return f'{generic}<{", ".join(insts)}>'
 
     if issubclass(typ, List):
+        # noinspection PyUnresolvedReferences
         trees = typ._subs_tree()
         if not is_tuple(trees):
             return 'List'

--- a/src/Modules/Trinity.FFI/Trinity.FFI.Python/Graph/utils.py
+++ b/src/Modules/Trinity.FFI/Trinity.FFI.Python/Graph/utils.py
@@ -37,6 +37,6 @@ class Record:
         cls_def.__str__ = __str__
         return cls_def
 
+
 def binding(cls):
     return cls
-

--- a/src/Modules/Trinity.FFI/Trinity.FFI.Python/tests/others/operations.i
+++ b/src/Modules/Trinity.FFI/Trinity.FFI.Python/tests/others/operations.i
@@ -6,34 +6,14 @@
 #include "swig_accessor.h"
 #include "CellAccessor.h"
 #define SWIG_FILE_WITH_INIT
-
-static void (* _Cell_C2_Set_bar)(void*, char*) = (void (*)(void*, char*))0x208606e00c0ll;
-static void Cell_C2_Set_bar(void* subject, char* object)
-{
-        return _Cell_C2_Set_bar(subject, object);
-}
-            
-
-static char* (* _Cell_C2_Get_bar)(void*) = (char* (*)(void*))0x208606e0080ll;
-static char* Cell_C2_Get_bar(void* subject)
-{
-        return _Cell_C2_Get_bar(subject);
-}
-            
-
-static void (* _Cell_C2_Set_lst)(void*, void*) = (void (*)(void*, void*))0x208606e0040ll;
-static void Cell_C2_Set_lst(void* subject, void* object)
-{
-        return _Cell_C2_Set_lst(subject, object);
-}
-            
-
-static void* (* _Cell_C2_Get_lst)(void*) = (void* (*)(void*))0x208606e0000ll;
-static void* Cell_C2_Get_lst(void* subject)
-{
-        return _Cell_C2_Get_lst(subject);
-}
-            
+static void (* _Set_Cell_C2(void*, void*) = (void (*)(void*, void*))0x177e8070200ll;static void Set_Cell_C2(void* subject, void* object){       return _Set_Cell_C2(subject, object);}
+static void* (* _Get_Cell_C2)(void*) = (void* (*)(void*))0x177e80701c0ll;static void* Get_Cell_C2(void *subject){       return _GetCell_C2(subject);}
+static void (* _Cell_C2_Set_bar)(void*, char*) = (void (*)(void*, char*))0x177e8070180ll;static void Cell_C2_Set_bar(void* subject, char* object){    return _Cell_C2_Set_bar(subject, object);}
+static char* (* _Cell_C2_Get_bar)(void*) = (char* (*)(void*))0x177e8070140ll;static char* Cell_C2_Get_bar(void* subject){    return _Cell_C2_Get_bar(subject);}
+static void (* _Set_Cell_C2(void*, void*) = (void (*)(void*, void*))0x177e80700c0ll;static void Set_Cell_C2(void* subject, void* object){       return _Set_Cell_C2(subject, object);}
+static void* (* _Get_Cell_C2)(void*) = (void* (*)(void*))0x177e8070080ll;static void* Get_Cell_C2(void *subject){       return _GetCell_C2(subject);}
+static void (* _Cell_C2_Set_lst)(void*, void*) = (void (*)(void*, void*))0x177e8070040ll;static void Cell_C2_Set_lst(void* subject, void* object){    return _Cell_C2_Set_lst(subject, object);}
+static void* (* _Cell_C2_Get_lst)(void*) = (void* (*)(void*))0x177e8070000ll;static void* Cell_C2_Get_lst(void* subject){    return _Cell_C2_Get_lst(subject);}
 
 CellAccessor* Use_Cell_C2(int64_t cellid, int32_t options)
 {
@@ -45,61 +25,18 @@ CellAccessor* Use_Cell_C2(int64_t cellid, int32_t options)
     return accessor;
 }
                                
-
-static int (* _List_int32_Count)(void*) = (int (*)(void* )) 0x208606e01c0ll;
-static int List_int32_Count(void* subject)
-{
-    return _List_int32_Count(subject);
-}
-            
-
-static bool (* _List_int32_Contains)(void*, int32_t) = (bool (*)(void*, int32_t)) 0x208606e0180ll;
-static bool List_int32_Contains(void* subject, int32_t object)
-{
-    return _List_int32_Contains(subject, object);
-}
-            
-
-static void (* _List_int32_Set)(void*, int,  int32_t) = (void (*)(void*, int, int32_t object))0x208606e0140ll;
-static void List_int32_Set(void* subject, int idx, int32_t object){
-        return _List_int32_Set(subject, idx, object);
-}
-            
-
-static int32_t (* _List_int32_Get)(void*, int) =  (int32_t (*)(void*, int))0x208606e0100ll;
-static int32_t List_int32_Get(void* subject, int idx)
-{
-        return _List_int32_Get(subject, idx);
-}
-            
-
-static void (* _Cell_C1_Set_bar)(void*, char*) = (void (*)(void*, char*))0x208606e02c0ll;
-static void Cell_C1_Set_bar(void* subject, char* object)
-{
-        return _Cell_C1_Set_bar(subject, object);
-}
-            
-
-static char* (* _Cell_C1_Get_bar)(void*) = (char* (*)(void*))0x208606e0280ll;
-static char* Cell_C1_Get_bar(void* subject)
-{
-        return _Cell_C1_Get_bar(subject);
-}
-            
-
-static void (* _Cell_C1_Set_foo)(void*, int32_t) = (void (*)(void*, int32_t))0x208606e0240ll;
-static void Cell_C1_Set_foo(void* subject, int32_t object)
-{
-        return _Cell_C1_Set_foo(subject, object);
-}
-            
-
-static int32_t (* _Cell_C1_Get_foo)(void*) = (int32_t (*)(void*))0x208606e0200ll;
-static int32_t Cell_C1_Get_foo(void* subject)
-{
-        return _Cell_C1_Get_foo(subject);
-}
-            
+static int (* _Count_List_int32)(void*) = (int (*)(void* )) 0x177e8070340ll;static int Count_List_int32(void* subject){    return _Count_List_int32(subject);}
+static bool (* _Contains_List_int32)(void*, int32_t) = (bool (*)(void*, int32_t)) 0x177e8070300ll;static bool Contains_List_int32(void* subject, int32_t object){    return _Contains_List_int32(subject, object);}
+static void (* _List_int32_Set)(void*, int,  int32_t) = (void (*)(void*, int, int32_t object))0x177e80702c0ll;static void List_int32_Set(void* subject, int idx, int32_t object){return _List_int32_Set(subject, idx, object);}
+static int32_t (* _List_int32_Get)(void*, int) =  (int32_t (*)(void*, int))0x177e8070280ll;static int32_t List_int32_Get(void* subject, int idx){        return _List_int32_Get(subject, idx);}
+static void (* _Set_Cell_C1(void*, void*) = (void (*)(void*, void*))0x177e8070580ll;static void Set_Cell_C1(void* subject, void* object){       return _Set_Cell_C1(subject, object);}
+static void* (* _Get_Cell_C1)(void*) = (void* (*)(void*))0x177e8070540ll;static void* Get_Cell_C1(void *subject){       return _GetCell_C1(subject);}
+static void (* _Cell_C1_Set_bar)(void*, char*) = (void (*)(void*, char*))0x177e8070500ll;static void Cell_C1_Set_bar(void* subject, char* object){    return _Cell_C1_Set_bar(subject, object);}
+static char* (* _Cell_C1_Get_bar)(void*) = (char* (*)(void*))0x177e80704c0ll;static char* Cell_C1_Get_bar(void* subject){    return _Cell_C1_Get_bar(subject);}
+static void (* _Set_Cell_C1(void*, void*) = (void (*)(void*, void*))0x177e8070440ll;static void Set_Cell_C1(void* subject, void* object){       return _Set_Cell_C1(subject, object);}
+static void* (* _Get_Cell_C1)(void*) = (void* (*)(void*))0x177e8070400ll;static void* Get_Cell_C1(void *subject){       return _GetCell_C1(subject);}
+static void (* _Cell_C1_Set_foo)(void*, int32_t) = (void (*)(void*, int32_t))0x177e80703c0ll;static void Cell_C1_Set_foo(void* subject, int32_t object){    return _Cell_C1_Set_foo(subject, object);}
+static int32_t (* _Cell_C1_Get_foo)(void*) = (int32_t (*)(void*))0x177e8070380ll;static int32_t Cell_C1_Get_foo(void* subject){    return _Cell_C1_Get_foo(subject);}
 
 CellAccessor* Use_Cell_C1(int64_t cellid, int32_t options)
 {
@@ -112,18 +49,26 @@ CellAccessor* Use_Cell_C1(int64_t cellid, int32_t options)
 }
                                
 %}
-static void Cell_C2_Set_bar(void* subject, char*);
+static void Set_Cell_C2(void*, void*);
+static void* Get_Cell_C2(void *);
+static void Cell_C2_Set_bar(void*, char*);
 static char* Cell_C2_Get_bar(void*);
-static void Cell_C2_Set_lst(void* subject, void*);
+static void Set_Cell_C2(void*, void*);
+static void* Get_Cell_C2(void *);
+static void Cell_C2_Set_lst(void*, void*);
 static void* Cell_C2_Get_lst(void*);
 CellAccessor* Use_Cell_C2(int64_t cellid, int32_t options);
-static int List_int32_Count(void* subject);
-static bool List_int32_Contains(void* subject, int32_t);
-static void List_int32_Set(void* subject, int idx, int32_t);
-static int32_t List_int32_Get(void* subject, int idx);
-static void Cell_C1_Set_bar(void* subject, char*);
+static int Count_List_int32(void* subject);
+static bool Contains_List_int32(void*, int32_t);
+static void List_int32_Set(void*, int, int32_t);
+static int32_t List_int32_Get(void*, int);
+static void Set_Cell_C1(void*, void*);
+static void* Get_Cell_C1(void *);
+static void Cell_C1_Set_bar(void*, char*);
 static char* Cell_C1_Get_bar(void*);
-static void Cell_C1_Set_foo(void* subject, int32_t);
+static void Set_Cell_C1(void*, void*);
+static void* Get_Cell_C1(void *);
+static void Cell_C1_Set_foo(void*, int32_t);
 static int32_t Cell_C1_Get_foo(void*);
 CellAccessor* Use_Cell_C1(int64_t cellid, int32_t options);
 %newobject Use_Cell_C2;

--- a/src/Modules/Trinity.FFI/Trinity.FFI.Python/tests/others/operations.i
+++ b/src/Modules/Trinity.FFI/Trinity.FFI.Python/tests/others/operations.i
@@ -6,14 +6,36 @@
 #include "swig_accessor.h"
 #include "CellAccessor.h"
 #define SWIG_FILE_WITH_INIT
-static void (* _Set_Cell_C2(void*, void*) = (void (*)(void*, void*))0x177e8070200ll;static void Set_Cell_C2(void* subject, void* object){       return _Set_Cell_C2(subject, object);}
-static void* (* _Get_Cell_C2)(void*) = (void* (*)(void*))0x177e80701c0ll;static void* Get_Cell_C2(void *subject){       return _GetCell_C2(subject);}
-static void (* _Cell_C2_Set_bar)(void*, char*) = (void (*)(void*, char*))0x177e8070180ll;static void Cell_C2_Set_bar(void* subject, char* object){    return _Cell_C2_Set_bar(subject, object);}
-static char* (* _Cell_C2_Get_bar)(void*) = (char* (*)(void*))0x177e8070140ll;static char* Cell_C2_Get_bar(void* subject){    return _Cell_C2_Get_bar(subject);}
-static void (* _Set_Cell_C2(void*, void*) = (void (*)(void*, void*))0x177e80700c0ll;static void Set_Cell_C2(void* subject, void* object){       return _Set_Cell_C2(subject, object);}
-static void* (* _Get_Cell_C2)(void*) = (void* (*)(void*))0x177e8070080ll;static void* Get_Cell_C2(void *subject){       return _GetCell_C2(subject);}
-static void (* _Cell_C2_Set_lst)(void*, void*) = (void (*)(void*, void*))0x177e8070040ll;static void Cell_C2_Set_lst(void* subject, void* object){    return _Cell_C2_Set_lst(subject, object);}
-static void* (* _Cell_C2_Get_lst)(void*) = (void* (*)(void*))0x177e8070000ll;static void* Cell_C2_Get_lst(void* subject){    return _Cell_C2_Get_lst(subject);}
+static void (* _Set_Cell_C2)(void*, void*) = (void (*)(void*, void*))0x1dc40430140ll;
+static void Set_Cell_C2(void* subject, void* object)
+{
+       return _Set_Cell_C2(subject, object);
+}
+static void* (* _Get_Cell_C2)(void*) = (void* (*)(void*))0x1dc40430100ll;
+static void* Get_Cell_C2(void *subject)
+{
+       return _Get_Cell_C2(subject);
+}
+static void (* _Cell_C2_Set_bar)(void*, char*) = (void (*)(void*, char*))0x1dc404300c0ll;
+static void Cell_C2_Set_bar(void* subject, char* object)
+{
+    return _Cell_C2_Set_bar(subject, object);
+}
+static char* (* _Cell_C2_Get_bar)(void*) = (char* (*)(void*))0x1dc40430080ll;
+static char* Cell_C2_Get_bar(void* subject)
+{
+    return _Cell_C2_Get_bar(subject);
+}
+static void (* _Cell_C2_Set_lst)(void*, void*) = (void (*)(void*, void*))0x1dc40430040ll;
+static void Cell_C2_Set_lst(void* subject, void* object)
+{
+    return _Cell_C2_Set_lst(subject, object);
+}
+static void* (* _Cell_C2_Get_lst)(void*) = (void* (*)(void*))0x1dc40430000ll;
+static void* Cell_C2_Get_lst(void* subject)
+{
+    return _Cell_C2_Get_lst(subject);
+}
 
 CellAccessor* Use_Cell_C2(int64_t cellid, int32_t options)
 {
@@ -25,18 +47,56 @@ CellAccessor* Use_Cell_C2(int64_t cellid, int32_t options)
     return accessor;
 }
                                
-static int (* _Count_List_int32)(void*) = (int (*)(void* )) 0x177e8070340ll;static int Count_List_int32(void* subject){    return _Count_List_int32(subject);}
-static bool (* _Contains_List_int32)(void*, int32_t) = (bool (*)(void*, int32_t)) 0x177e8070300ll;static bool Contains_List_int32(void* subject, int32_t object){    return _Contains_List_int32(subject, object);}
-static void (* _List_int32_Set)(void*, int,  int32_t) = (void (*)(void*, int, int32_t object))0x177e80702c0ll;static void List_int32_Set(void* subject, int idx, int32_t object){return _List_int32_Set(subject, idx, object);}
-static int32_t (* _List_int32_Get)(void*, int) =  (int32_t (*)(void*, int))0x177e8070280ll;static int32_t List_int32_Get(void* subject, int idx){        return _List_int32_Get(subject, idx);}
-static void (* _Set_Cell_C1(void*, void*) = (void (*)(void*, void*))0x177e8070580ll;static void Set_Cell_C1(void* subject, void* object){       return _Set_Cell_C1(subject, object);}
-static void* (* _Get_Cell_C1)(void*) = (void* (*)(void*))0x177e8070540ll;static void* Get_Cell_C1(void *subject){       return _GetCell_C1(subject);}
-static void (* _Cell_C1_Set_bar)(void*, char*) = (void (*)(void*, char*))0x177e8070500ll;static void Cell_C1_Set_bar(void* subject, char* object){    return _Cell_C1_Set_bar(subject, object);}
-static char* (* _Cell_C1_Get_bar)(void*) = (char* (*)(void*))0x177e80704c0ll;static char* Cell_C1_Get_bar(void* subject){    return _Cell_C1_Get_bar(subject);}
-static void (* _Set_Cell_C1(void*, void*) = (void (*)(void*, void*))0x177e8070440ll;static void Set_Cell_C1(void* subject, void* object){       return _Set_Cell_C1(subject, object);}
-static void* (* _Get_Cell_C1)(void*) = (void* (*)(void*))0x177e8070400ll;static void* Get_Cell_C1(void *subject){       return _GetCell_C1(subject);}
-static void (* _Cell_C1_Set_foo)(void*, int32_t) = (void (*)(void*, int32_t))0x177e80703c0ll;static void Cell_C1_Set_foo(void* subject, int32_t object){    return _Cell_C1_Set_foo(subject, object);}
-static int32_t (* _Cell_C1_Get_foo)(void*) = (int32_t (*)(void*))0x177e8070380ll;static int32_t Cell_C1_Get_foo(void* subject){    return _Cell_C1_Get_foo(subject);}
+static int (* _Count_List_int32)(void*) = (int (*)(void* )) 0x1dc40430280ll;
+static int Count_List_int32(void* subject)
+{
+    return _Count_List_int32(subject);
+}
+static bool (* _Contains_List_int32)(void*, int32_t) = (bool (*)(void*, int32_t)) 0x1dc40430240ll;
+static bool Contains_List_int32(void* subject, int32_t object)
+{
+    return _Contains_List_int32(subject, object);
+}
+static void (* _List_int32_Set)(void*, int,  int32_t) = (void (*)(void*, int, int32_t object))0x1dc40430200ll;
+static void List_int32_Set(void* subject, int idx, int32_t object)
+{
+return _List_int32_Set(subject, idx, object);
+}
+static int32_t (* _List_int32_Get)(void*, int) =  (int32_t (*)(void*, int))0x1dc404301c0ll;
+static int32_t List_int32_Get(void* subject, int idx)
+{
+        return _List_int32_Get(subject, idx);
+}
+static void (* _Set_Cell_C1)(void*, void*) = (void (*)(void*, void*))0x1dc40430400ll;
+static void Set_Cell_C1(void* subject, void* object)
+{
+       return _Set_Cell_C1(subject, object);
+}
+static void* (* _Get_Cell_C1)(void*) = (void* (*)(void*))0x1dc404303c0ll;
+static void* Get_Cell_C1(void *subject)
+{
+       return _Get_Cell_C1(subject);
+}
+static void (* _Cell_C1_Set_bar)(void*, char*) = (void (*)(void*, char*))0x1dc40430380ll;
+static void Cell_C1_Set_bar(void* subject, char* object)
+{
+    return _Cell_C1_Set_bar(subject, object);
+}
+static char* (* _Cell_C1_Get_bar)(void*) = (char* (*)(void*))0x1dc40430340ll;
+static char* Cell_C1_Get_bar(void* subject)
+{
+    return _Cell_C1_Get_bar(subject);
+}
+static void (* _Cell_C1_Set_foo)(void*, int32_t) = (void (*)(void*, int32_t))0x1dc40430300ll;
+static void Cell_C1_Set_foo(void* subject, int32_t object)
+{
+    return _Cell_C1_Set_foo(subject, object);
+}
+static int32_t (* _Cell_C1_Get_foo)(void*) = (int32_t (*)(void*))0x1dc404302c0ll;
+static int32_t Cell_C1_Get_foo(void* subject)
+{
+    return _Cell_C1_Get_foo(subject);
+}
 
 CellAccessor* Use_Cell_C1(int64_t cellid, int32_t options)
 {
@@ -53,8 +113,6 @@ static void Set_Cell_C2(void*, void*);
 static void* Get_Cell_C2(void *);
 static void Cell_C2_Set_bar(void*, char*);
 static char* Cell_C2_Get_bar(void*);
-static void Set_Cell_C2(void*, void*);
-static void* Get_Cell_C2(void *);
 static void Cell_C2_Set_lst(void*, void*);
 static void* Cell_C2_Get_lst(void*);
 CellAccessor* Use_Cell_C2(int64_t cellid, int32_t options);
@@ -66,8 +124,6 @@ static void Set_Cell_C1(void*, void*);
 static void* Get_Cell_C1(void *);
 static void Cell_C1_Set_bar(void*, char*);
 static char* Cell_C1_Get_bar(void*);
-static void Set_Cell_C1(void*, void*);
-static void* Get_Cell_C1(void *);
 static void Cell_C1_Set_foo(void*, int32_t);
 static int32_t Cell_C1_Get_foo(void*);
 CellAccessor* Use_Cell_C1(int64_t cellid, int32_t options);

--- a/src/Modules/Trinity.FFI/Trinity.FFI.Python/tests/others/operations_wrap.cxx
+++ b/src/Modules/Trinity.FFI/Trinity.FFI.Python/tests/others/operations_wrap.cxx
@@ -3672,14 +3672,36 @@ namespace swig {
 #include "swig_accessor.h"
 #include "CellAccessor.h"
 #define SWIG_FILE_WITH_INIT
-static void (* _Set_Cell_C2(void*, void*) = (void (*)(void*, void*))0x177e8070200ll;static void Set_Cell_C2(void* subject, void* object){       return _Set_Cell_C2(subject, object);}
-static void* (* _Get_Cell_C2)(void*) = (void* (*)(void*))0x177e80701c0ll;static void* Get_Cell_C2(void *subject){       return _GetCell_C2(subject);}
-static void (* _Cell_C2_Set_bar)(void*, char*) = (void (*)(void*, char*))0x177e8070180ll;static void Cell_C2_Set_bar(void* subject, char* object){    return _Cell_C2_Set_bar(subject, object);}
-static char* (* _Cell_C2_Get_bar)(void*) = (char* (*)(void*))0x177e8070140ll;static char* Cell_C2_Get_bar(void* subject){    return _Cell_C2_Get_bar(subject);}
-static void (* _Set_Cell_C2(void*, void*) = (void (*)(void*, void*))0x177e80700c0ll;static void Set_Cell_C2(void* subject, void* object){       return _Set_Cell_C2(subject, object);}
-static void* (* _Get_Cell_C2)(void*) = (void* (*)(void*))0x177e8070080ll;static void* Get_Cell_C2(void *subject){       return _GetCell_C2(subject);}
-static void (* _Cell_C2_Set_lst)(void*, void*) = (void (*)(void*, void*))0x177e8070040ll;static void Cell_C2_Set_lst(void* subject, void* object){    return _Cell_C2_Set_lst(subject, object);}
-static void* (* _Cell_C2_Get_lst)(void*) = (void* (*)(void*))0x177e8070000ll;static void* Cell_C2_Get_lst(void* subject){    return _Cell_C2_Get_lst(subject);}
+static void (* _Set_Cell_C2)(void*, void*) = (void (*)(void*, void*))0x1dc40430140ll;
+static void Set_Cell_C2(void* subject, void* object)
+{
+       return _Set_Cell_C2(subject, object);
+}
+static void* (* _Get_Cell_C2)(void*) = (void* (*)(void*))0x1dc40430100ll;
+static void* Get_Cell_C2(void *subject)
+{
+       return _Get_Cell_C2(subject);
+}
+static void (* _Cell_C2_Set_bar)(void*, char*) = (void (*)(void*, char*))0x1dc404300c0ll;
+static void Cell_C2_Set_bar(void* subject, char* object)
+{
+    return _Cell_C2_Set_bar(subject, object);
+}
+static char* (* _Cell_C2_Get_bar)(void*) = (char* (*)(void*))0x1dc40430080ll;
+static char* Cell_C2_Get_bar(void* subject)
+{
+    return _Cell_C2_Get_bar(subject);
+}
+static void (* _Cell_C2_Set_lst)(void*, void*) = (void (*)(void*, void*))0x1dc40430040ll;
+static void Cell_C2_Set_lst(void* subject, void* object)
+{
+    return _Cell_C2_Set_lst(subject, object);
+}
+static void* (* _Cell_C2_Get_lst)(void*) = (void* (*)(void*))0x1dc40430000ll;
+static void* Cell_C2_Get_lst(void* subject)
+{
+    return _Cell_C2_Get_lst(subject);
+}
 
 CellAccessor* Use_Cell_C2(int64_t cellid, int32_t options)
 {
@@ -3691,18 +3713,56 @@ CellAccessor* Use_Cell_C2(int64_t cellid, int32_t options)
     return accessor;
 }
                                
-static int (* _Count_List_int32)(void*) = (int (*)(void* )) 0x177e8070340ll;static int Count_List_int32(void* subject){    return _Count_List_int32(subject);}
-static bool (* _Contains_List_int32)(void*, int32_t) = (bool (*)(void*, int32_t)) 0x177e8070300ll;static bool Contains_List_int32(void* subject, int32_t object){    return _Contains_List_int32(subject, object);}
-static void (* _List_int32_Set)(void*, int,  int32_t) = (void (*)(void*, int, int32_t object))0x177e80702c0ll;static void List_int32_Set(void* subject, int idx, int32_t object){return _List_int32_Set(subject, idx, object);}
-static int32_t (* _List_int32_Get)(void*, int) =  (int32_t (*)(void*, int))0x177e8070280ll;static int32_t List_int32_Get(void* subject, int idx){        return _List_int32_Get(subject, idx);}
-static void (* _Set_Cell_C1(void*, void*) = (void (*)(void*, void*))0x177e8070580ll;static void Set_Cell_C1(void* subject, void* object){       return _Set_Cell_C1(subject, object);}
-static void* (* _Get_Cell_C1)(void*) = (void* (*)(void*))0x177e8070540ll;static void* Get_Cell_C1(void *subject){       return _GetCell_C1(subject);}
-static void (* _Cell_C1_Set_bar)(void*, char*) = (void (*)(void*, char*))0x177e8070500ll;static void Cell_C1_Set_bar(void* subject, char* object){    return _Cell_C1_Set_bar(subject, object);}
-static char* (* _Cell_C1_Get_bar)(void*) = (char* (*)(void*))0x177e80704c0ll;static char* Cell_C1_Get_bar(void* subject){    return _Cell_C1_Get_bar(subject);}
-static void (* _Set_Cell_C1(void*, void*) = (void (*)(void*, void*))0x177e8070440ll;static void Set_Cell_C1(void* subject, void* object){       return _Set_Cell_C1(subject, object);}
-static void* (* _Get_Cell_C1)(void*) = (void* (*)(void*))0x177e8070400ll;static void* Get_Cell_C1(void *subject){       return _GetCell_C1(subject);}
-static void (* _Cell_C1_Set_foo)(void*, int32_t) = (void (*)(void*, int32_t))0x177e80703c0ll;static void Cell_C1_Set_foo(void* subject, int32_t object){    return _Cell_C1_Set_foo(subject, object);}
-static int32_t (* _Cell_C1_Get_foo)(void*) = (int32_t (*)(void*))0x177e8070380ll;static int32_t Cell_C1_Get_foo(void* subject){    return _Cell_C1_Get_foo(subject);}
+static int (* _Count_List_int32)(void*) = (int (*)(void* )) 0x1dc40430280ll;
+static int Count_List_int32(void* subject)
+{
+    return _Count_List_int32(subject);
+}
+static bool (* _Contains_List_int32)(void*, int32_t) = (bool (*)(void*, int32_t)) 0x1dc40430240ll;
+static bool Contains_List_int32(void* subject, int32_t object)
+{
+    return _Contains_List_int32(subject, object);
+}
+static void (* _List_int32_Set)(void*, int,  int32_t) = (void (*)(void*, int, int32_t object))0x1dc40430200ll;
+static void List_int32_Set(void* subject, int idx, int32_t object)
+{
+return _List_int32_Set(subject, idx, object);
+}
+static int32_t (* _List_int32_Get)(void*, int) =  (int32_t (*)(void*, int))0x1dc404301c0ll;
+static int32_t List_int32_Get(void* subject, int idx)
+{
+        return _List_int32_Get(subject, idx);
+}
+static void (* _Set_Cell_C1)(void*, void*) = (void (*)(void*, void*))0x1dc40430400ll;
+static void Set_Cell_C1(void* subject, void* object)
+{
+       return _Set_Cell_C1(subject, object);
+}
+static void* (* _Get_Cell_C1)(void*) = (void* (*)(void*))0x1dc404303c0ll;
+static void* Get_Cell_C1(void *subject)
+{
+       return _Get_Cell_C1(subject);
+}
+static void (* _Cell_C1_Set_bar)(void*, char*) = (void (*)(void*, char*))0x1dc40430380ll;
+static void Cell_C1_Set_bar(void* subject, char* object)
+{
+    return _Cell_C1_Set_bar(subject, object);
+}
+static char* (* _Cell_C1_Get_bar)(void*) = (char* (*)(void*))0x1dc40430340ll;
+static char* Cell_C1_Get_bar(void* subject)
+{
+    return _Cell_C1_Get_bar(subject);
+}
+static void (* _Cell_C1_Set_foo)(void*, int32_t) = (void (*)(void*, int32_t))0x1dc40430300ll;
+static void Cell_C1_Set_foo(void* subject, int32_t object)
+{
+    return _Cell_C1_Set_foo(subject, object);
+}
+static int32_t (* _Cell_C1_Get_foo)(void*) = (int32_t (*)(void*))0x1dc404302c0ll;
+static int32_t Cell_C1_Get_foo(void* subject)
+{
+    return _Cell_C1_Get_foo(subject);
+}
 
 CellAccessor* Use_Cell_C1(int64_t cellid, int32_t options)
 {

--- a/src/Modules/Trinity.FFI/Trinity.FFI.Python/tests/others/operations_wrap.cxx
+++ b/src/Modules/Trinity.FFI/Trinity.FFI.Python/tests/others/operations_wrap.cxx
@@ -3672,34 +3672,14 @@ namespace swig {
 #include "swig_accessor.h"
 #include "CellAccessor.h"
 #define SWIG_FILE_WITH_INIT
-
-static void (* _Cell_C2_Set_bar)(void*, char*) = (void (*)(void*, char*))0x208606e00c0ll;
-static void Cell_C2_Set_bar(void* subject, char* object)
-{
-        return _Cell_C2_Set_bar(subject, object);
-}
-            
-
-static char* (* _Cell_C2_Get_bar)(void*) = (char* (*)(void*))0x208606e0080ll;
-static char* Cell_C2_Get_bar(void* subject)
-{
-        return _Cell_C2_Get_bar(subject);
-}
-            
-
-static void (* _Cell_C2_Set_lst)(void*, void*) = (void (*)(void*, void*))0x208606e0040ll;
-static void Cell_C2_Set_lst(void* subject, void* object)
-{
-        return _Cell_C2_Set_lst(subject, object);
-}
-            
-
-static void* (* _Cell_C2_Get_lst)(void*) = (void* (*)(void*))0x208606e0000ll;
-static void* Cell_C2_Get_lst(void* subject)
-{
-        return _Cell_C2_Get_lst(subject);
-}
-            
+static void (* _Set_Cell_C2(void*, void*) = (void (*)(void*, void*))0x177e8070200ll;static void Set_Cell_C2(void* subject, void* object){       return _Set_Cell_C2(subject, object);}
+static void* (* _Get_Cell_C2)(void*) = (void* (*)(void*))0x177e80701c0ll;static void* Get_Cell_C2(void *subject){       return _GetCell_C2(subject);}
+static void (* _Cell_C2_Set_bar)(void*, char*) = (void (*)(void*, char*))0x177e8070180ll;static void Cell_C2_Set_bar(void* subject, char* object){    return _Cell_C2_Set_bar(subject, object);}
+static char* (* _Cell_C2_Get_bar)(void*) = (char* (*)(void*))0x177e8070140ll;static char* Cell_C2_Get_bar(void* subject){    return _Cell_C2_Get_bar(subject);}
+static void (* _Set_Cell_C2(void*, void*) = (void (*)(void*, void*))0x177e80700c0ll;static void Set_Cell_C2(void* subject, void* object){       return _Set_Cell_C2(subject, object);}
+static void* (* _Get_Cell_C2)(void*) = (void* (*)(void*))0x177e8070080ll;static void* Get_Cell_C2(void *subject){       return _GetCell_C2(subject);}
+static void (* _Cell_C2_Set_lst)(void*, void*) = (void (*)(void*, void*))0x177e8070040ll;static void Cell_C2_Set_lst(void* subject, void* object){    return _Cell_C2_Set_lst(subject, object);}
+static void* (* _Cell_C2_Get_lst)(void*) = (void* (*)(void*))0x177e8070000ll;static void* Cell_C2_Get_lst(void* subject){    return _Cell_C2_Get_lst(subject);}
 
 CellAccessor* Use_Cell_C2(int64_t cellid, int32_t options)
 {
@@ -3711,61 +3691,18 @@ CellAccessor* Use_Cell_C2(int64_t cellid, int32_t options)
     return accessor;
 }
                                
-
-static int (* _List_int32_Count)(void*) = (int (*)(void* )) 0x208606e01c0ll;
-static int List_int32_Count(void* subject)
-{
-    return _List_int32_Count(subject);
-}
-            
-
-static bool (* _List_int32_Contains)(void*, int32_t) = (bool (*)(void*, int32_t)) 0x208606e0180ll;
-static bool List_int32_Contains(void* subject, int32_t object)
-{
-    return _List_int32_Contains(subject, object);
-}
-            
-
-static void (* _List_int32_Set)(void*, int,  int32_t) = (void (*)(void*, int, int32_t object))0x208606e0140ll;
-static void List_int32_Set(void* subject, int idx, int32_t object){
-        return _List_int32_Set(subject, idx, object);
-}
-            
-
-static int32_t (* _List_int32_Get)(void*, int) =  (int32_t (*)(void*, int))0x208606e0100ll;
-static int32_t List_int32_Get(void* subject, int idx)
-{
-        return _List_int32_Get(subject, idx);
-}
-            
-
-static void (* _Cell_C1_Set_bar)(void*, char*) = (void (*)(void*, char*))0x208606e02c0ll;
-static void Cell_C1_Set_bar(void* subject, char* object)
-{
-        return _Cell_C1_Set_bar(subject, object);
-}
-            
-
-static char* (* _Cell_C1_Get_bar)(void*) = (char* (*)(void*))0x208606e0280ll;
-static char* Cell_C1_Get_bar(void* subject)
-{
-        return _Cell_C1_Get_bar(subject);
-}
-            
-
-static void (* _Cell_C1_Set_foo)(void*, int32_t) = (void (*)(void*, int32_t))0x208606e0240ll;
-static void Cell_C1_Set_foo(void* subject, int32_t object)
-{
-        return _Cell_C1_Set_foo(subject, object);
-}
-            
-
-static int32_t (* _Cell_C1_Get_foo)(void*) = (int32_t (*)(void*))0x208606e0200ll;
-static int32_t Cell_C1_Get_foo(void* subject)
-{
-        return _Cell_C1_Get_foo(subject);
-}
-            
+static int (* _Count_List_int32)(void*) = (int (*)(void* )) 0x177e8070340ll;static int Count_List_int32(void* subject){    return _Count_List_int32(subject);}
+static bool (* _Contains_List_int32)(void*, int32_t) = (bool (*)(void*, int32_t)) 0x177e8070300ll;static bool Contains_List_int32(void* subject, int32_t object){    return _Contains_List_int32(subject, object);}
+static void (* _List_int32_Set)(void*, int,  int32_t) = (void (*)(void*, int, int32_t object))0x177e80702c0ll;static void List_int32_Set(void* subject, int idx, int32_t object){return _List_int32_Set(subject, idx, object);}
+static int32_t (* _List_int32_Get)(void*, int) =  (int32_t (*)(void*, int))0x177e8070280ll;static int32_t List_int32_Get(void* subject, int idx){        return _List_int32_Get(subject, idx);}
+static void (* _Set_Cell_C1(void*, void*) = (void (*)(void*, void*))0x177e8070580ll;static void Set_Cell_C1(void* subject, void* object){       return _Set_Cell_C1(subject, object);}
+static void* (* _Get_Cell_C1)(void*) = (void* (*)(void*))0x177e8070540ll;static void* Get_Cell_C1(void *subject){       return _GetCell_C1(subject);}
+static void (* _Cell_C1_Set_bar)(void*, char*) = (void (*)(void*, char*))0x177e8070500ll;static void Cell_C1_Set_bar(void* subject, char* object){    return _Cell_C1_Set_bar(subject, object);}
+static char* (* _Cell_C1_Get_bar)(void*) = (char* (*)(void*))0x177e80704c0ll;static char* Cell_C1_Get_bar(void* subject){    return _Cell_C1_Get_bar(subject);}
+static void (* _Set_Cell_C1(void*, void*) = (void (*)(void*, void*))0x177e8070440ll;static void Set_Cell_C1(void* subject, void* object){       return _Set_Cell_C1(subject, object);}
+static void* (* _Get_Cell_C1)(void*) = (void* (*)(void*))0x177e8070400ll;static void* Get_Cell_C1(void *subject){       return _GetCell_C1(subject);}
+static void (* _Cell_C1_Set_foo)(void*, int32_t) = (void (*)(void*, int32_t))0x177e80703c0ll;static void Cell_C1_Set_foo(void* subject, int32_t object){    return _Cell_C1_Set_foo(subject, object);}
+static int32_t (* _Cell_C1_Get_foo)(void*) = (int32_t (*)(void*))0x177e8070380ll;static int32_t Cell_C1_Get_foo(void* subject){    return _Cell_C1_Get_foo(subject);}
 
 CellAccessor* Use_Cell_C1(int64_t cellid, int32_t options)
 {
@@ -4156,6 +4093,52 @@ SWIGINTERNINLINE PyObject*
 #ifdef __cplusplus
 extern "C" {
 #endif
+SWIGINTERN PyObject *_wrap_Set_Cell_C2(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  void *arg1 = (void *) 0 ;
+  void *arg2 = (void *) 0 ;
+  int res1 ;
+  int res2 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if(!PyArg_UnpackTuple(args,(char *)"Set_Cell_C2",2,2,&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0,SWIG_as_voidptrptr(&arg1), 0, 0);
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Set_Cell_C2" "', argument " "1"" of type '" "void *""'"); 
+  }
+  res2 = SWIG_ConvertPtr(obj1,SWIG_as_voidptrptr(&arg2), 0, 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Set_Cell_C2" "', argument " "2"" of type '" "void *""'"); 
+  }
+  Set_Cell_C2(arg1,arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_Get_Cell_C2(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  void *arg1 = (void *) 0 ;
+  int res1 ;
+  PyObject * obj0 = 0 ;
+  void *result = 0 ;
+  
+  if(!PyArg_UnpackTuple(args,(char *)"Get_Cell_C2",1,1,&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0,SWIG_as_voidptrptr(&arg1), 0, 0);
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Get_Cell_C2" "', argument " "1"" of type '" "void *""'"); 
+  }
+  result = (void *)Get_Cell_C2(arg1);
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_void, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_Cell_C2_Set_bar(PyObject *self, PyObject *args) {
   PyObject *resultobj = 0;
   void *arg1 = (void *) 0 ;
@@ -4284,19 +4267,19 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_List_int32_Count(PyObject *self, PyObject *args) {
+SWIGINTERN PyObject *_wrap_Count_List_int32(PyObject *self, PyObject *args) {
   PyObject *resultobj = 0;
   void *arg1 = (void *) 0 ;
   int res1 ;
   PyObject * obj0 = 0 ;
   int result;
   
-  if(!PyArg_UnpackTuple(args,(char *)"List_int32_Count",1,1,&obj0)) SWIG_fail;
+  if(!PyArg_UnpackTuple(args,(char *)"Count_List_int32",1,1,&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0,SWIG_as_voidptrptr(&arg1), 0, 0);
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "List_int32_Count" "', argument " "1"" of type '" "void *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Count_List_int32" "', argument " "1"" of type '" "void *""'"); 
   }
-  result = (int)List_int32_Count(arg1);
+  result = (int)Count_List_int32(arg1);
   resultobj = SWIG_From_int(static_cast< int >(result));
   return resultobj;
 fail:
@@ -4304,7 +4287,7 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_List_int32_Contains(PyObject *self, PyObject *args) {
+SWIGINTERN PyObject *_wrap_Contains_List_int32(PyObject *self, PyObject *args) {
   PyObject *resultobj = 0;
   void *arg1 = (void *) 0 ;
   int32_t arg2 ;
@@ -4315,17 +4298,17 @@ SWIGINTERN PyObject *_wrap_List_int32_Contains(PyObject *self, PyObject *args) {
   PyObject * obj1 = 0 ;
   bool result;
   
-  if(!PyArg_UnpackTuple(args,(char *)"List_int32_Contains",2,2,&obj0,&obj1)) SWIG_fail;
+  if(!PyArg_UnpackTuple(args,(char *)"Contains_List_int32",2,2,&obj0,&obj1)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0,SWIG_as_voidptrptr(&arg1), 0, 0);
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "List_int32_Contains" "', argument " "1"" of type '" "void *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Contains_List_int32" "', argument " "1"" of type '" "void *""'"); 
   }
   ecode2 = SWIG_AsVal_int(obj1, &val2);
   if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "List_int32_Contains" "', argument " "2"" of type '" "int32_t""'");
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "Contains_List_int32" "', argument " "2"" of type '" "int32_t""'");
   } 
   arg2 = static_cast< int32_t >(val2);
-  result = (bool)List_int32_Contains(arg1,arg2);
+  result = (bool)Contains_List_int32(arg1,arg2);
   resultobj = SWIG_From_bool(static_cast< bool >(result));
   return resultobj;
 fail:
@@ -4393,6 +4376,52 @@ SWIGINTERN PyObject *_wrap_List_int32_Get(PyObject *self, PyObject *args) {
   arg2 = static_cast< int >(val2);
   result = (int32_t)List_int32_Get(arg1,arg2);
   resultobj = SWIG_From_int(static_cast< int >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_Set_Cell_C1(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  void *arg1 = (void *) 0 ;
+  void *arg2 = (void *) 0 ;
+  int res1 ;
+  int res2 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if(!PyArg_UnpackTuple(args,(char *)"Set_Cell_C1",2,2,&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0,SWIG_as_voidptrptr(&arg1), 0, 0);
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Set_Cell_C1" "', argument " "1"" of type '" "void *""'"); 
+  }
+  res2 = SWIG_ConvertPtr(obj1,SWIG_as_voidptrptr(&arg2), 0, 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Set_Cell_C1" "', argument " "2"" of type '" "void *""'"); 
+  }
+  Set_Cell_C1(arg1,arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_Get_Cell_C1(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  void *arg1 = (void *) 0 ;
+  int res1 ;
+  PyObject * obj0 = 0 ;
+  void *result = 0 ;
+  
+  if(!PyArg_UnpackTuple(args,(char *)"Get_Cell_C1",1,1,&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0,SWIG_as_voidptrptr(&arg1), 0, 0);
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Get_Cell_C1" "', argument " "1"" of type '" "void *""'"); 
+  }
+  result = (void *)Get_Cell_C1(arg1);
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_void, 0 |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -4531,15 +4560,19 @@ fail:
 
 static PyMethodDef SwigMethods[] = {
 	 { (char *)"SWIG_PyInstanceMethod_New", (PyCFunction)SWIG_PyInstanceMethod_New, METH_O, NULL},
+	 { (char *)"Set_Cell_C2", _wrap_Set_Cell_C2, METH_VARARGS, NULL},
+	 { (char *)"Get_Cell_C2", _wrap_Get_Cell_C2, METH_VARARGS, NULL},
 	 { (char *)"Cell_C2_Set_bar", _wrap_Cell_C2_Set_bar, METH_VARARGS, NULL},
 	 { (char *)"Cell_C2_Get_bar", _wrap_Cell_C2_Get_bar, METH_VARARGS, NULL},
 	 { (char *)"Cell_C2_Set_lst", _wrap_Cell_C2_Set_lst, METH_VARARGS, NULL},
 	 { (char *)"Cell_C2_Get_lst", _wrap_Cell_C2_Get_lst, METH_VARARGS, NULL},
 	 { (char *)"Use_Cell_C2", _wrap_Use_Cell_C2, METH_VARARGS, NULL},
-	 { (char *)"List_int32_Count", _wrap_List_int32_Count, METH_VARARGS, NULL},
-	 { (char *)"List_int32_Contains", _wrap_List_int32_Contains, METH_VARARGS, NULL},
+	 { (char *)"Count_List_int32", _wrap_Count_List_int32, METH_VARARGS, NULL},
+	 { (char *)"Contains_List_int32", _wrap_Contains_List_int32, METH_VARARGS, NULL},
 	 { (char *)"List_int32_Set", _wrap_List_int32_Set, METH_VARARGS, NULL},
 	 { (char *)"List_int32_Get", _wrap_List_int32_Get, METH_VARARGS, NULL},
+	 { (char *)"Set_Cell_C1", _wrap_Set_Cell_C1, METH_VARARGS, NULL},
+	 { (char *)"Get_Cell_C1", _wrap_Get_Cell_C1, METH_VARARGS, NULL},
 	 { (char *)"Cell_C1_Set_bar", _wrap_Cell_C1_Set_bar, METH_VARARGS, NULL},
 	 { (char *)"Cell_C1_Get_bar", _wrap_Cell_C1_Get_bar, METH_VARARGS, NULL},
 	 { (char *)"Cell_C1_Set_foo", _wrap_Cell_C1_Set_foo, METH_VARARGS, NULL},

--- a/src/Modules/Trinity.FFI/Trinity.FFI.Python/tests/others/setup.py
+++ b/src/Modules/Trinity.FFI/Trinity.FFI.Python/tests/others/setup.py
@@ -4,12 +4,12 @@ from setuptools.extension import Extension
 
 ext = Extension('_operations',
                       sources=['operations_wrap.cxx'],
-                      include_dirs=[r'C:\Users\yatli\.nuget\packages\graphengine.ffi.metagen\2.0.9328\content\include'],
+                      include_dirs=[r'C:\Users\twshe\.nuget\packages\graphengine.ffi.metagen\2.0.9328\content\include'],
                       libraries=['trinity_ffi'],
-                      library_dirs=[r'C:\Users\yatli\.nuget\packages\graphengine.ffi.metagen\2.0.9328\content\win-x64'])
+                      library_dirs=[r'C:\Users\twshe\.nuget\packages\graphengine.ffi.metagen\2.0.9328\content\win-x64'])
 
 setup(name='operations',
 	ext_modules=[ext],
 	version = '0.1',
-    author      = "yatli",
+    author      = "twshe",
 	py_modules = ["operations"])


### PR DESCRIPTION
In this thread, metegen analyzer will find out whether a getter return a primitive one, and if so, the exported verb  would be `ComposedVerb(SGet _/LGet, BGet)`.  


And now Trinity.FFI.Metagen.UnitTests has also been updated, here is an example to briefly explain the differences:

- old codes:
```C#
 var get_foo_from_c1 =
        fnDescs
        .First()
        .By(
            _ => 
            JitCompiler.CompileFunction(
                new Verbs.FunctionDescriptor(
                    _.DeclaringType,
                    Verbs.Verb.NewComposedVerb(_.Verb, Verbs.Verb.BGet)
                    )))
        .By(native => 
            Marshal.GetDelegateForFunctionPointer(
                native.CallSite, typeof(TestFnType)));
``` 
- the new
```C#
var get_foo_from_c1 =
           fnDescs
           .First()
           .By(JitCompiler.CompileFunction)
           .By(native => 
               Marshal.GetDelegateForFunctionPointer(
                   native.CallSite, typeof(TestFnType)));
``` 

Now we can simply think 
-  get object from subject :  returning/argument passing by reference if not primitive.
 ```python
   c1 = C1()
   field = c1.field 
   # field is just an actually deep-copied one which could be  
   # represented in Python runtime if it's primitive. 
   # Or it's a swig-wrapped object(void*)
   # TODO: maybe (w)char* should be passed as (void*)
 ```
- `User...`: get exactly the reference of the data in storage(lock the data as well).  
   (can be only applied at struct/cell/list<T>

Additionally, we  now export the functions for getting data from (cell/struct/list)accessor.
```python
c1 = C1()
c1_deep_copied = Get_C1(c1) 
```
