### PR TITLE
GraphEngine.Client: IKeyValueStore interfaces

### DIFF
--- a/src/Modules/GraphEngine.Client/README.md
+++ b/src/Modules/GraphEngine.Client/README.md
@@ -1,0 +1,29 @@
+﻿= Module `GraphEngine.Client` =
+
+Provides client-side communication instance. In a GraphEngine application,
+a client is by-default not a communication instance -- for that it does not
+possess message handling capabilities. `GraphEngine.Client` extends both the
+client and the server to support client-side message handling through a single
+messaging endpoint, while preserving the ability to access the whole memory
+cloud.
+
+When a client communication instance starts, it connects to the server with
+a customizable messaging endpoint. The endpoint should implement the interface
+`IMessagePassingEndpoint`, but is not limited to using native Trinity protocol.
+Therefore we could implement the interface with any messaging transport, e.g.
+WCF, gRPC etc. Once the endpoint establishes connection, the client registers
+itself at the destination server with a randomly generated cookie. The server
+keeps track of the connected clients, and assigns a TTL value to each client.
+The server does not initiate new connections to the clients, but rather,
+responds to client-side polling. New client-going messages are first queued at
+the server, and piggybacked during polling. This allows a client to send
+asynchronous messages, without being blocked by a single request/response pair
+on the endpoint.
+
+This module also implements `MemoryCloud` for both client and server. The
+server side uses `HostedMemoryCloud: FixedMemoryCloud` and provides
+aforementioned client-registration services. The client side uses
+`ClientMemoryCloud: MemoryCloud`, which takes a single message passing endpoint
+(rather than connecting to every remote storage in the cluster), and send all
+messages as redirected messages, and all key-value store operations as custom
+remote calls, which are handled in `TrinityClientModule`.

--- a/src/Modules/GraphEngine.Client/Trinity.Client.TestClient/Program.cs
+++ b/src/Modules/GraphEngine.Client/Trinity.Client.TestClient/Program.cs
@@ -18,8 +18,6 @@ namespace Trinity.Client.TestClient
             client.RegisterCommunicationModule<TrinityClientTestModule>();
             client.Start();
 
-            Console.WriteLine(Global.CloudStorage.LoadC1(0));
-
             while (true) Thread.Sleep(1000000);
         }
     }

--- a/src/Modules/GraphEngine.Client/Trinity.Client.TestClient/Program.cs
+++ b/src/Modules/GraphEngine.Client/Trinity.Client.TestClient/Program.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Trinity.Client.TestProtocols;
 using Trinity.Client.TestProtocols.Impl;
 
 namespace Trinity.Client.TestClient
@@ -16,6 +17,8 @@ namespace Trinity.Client.TestClient
             TrinityClient client = new TrinityClient("localhost:5304");
             client.RegisterCommunicationModule<TrinityClientTestModule>();
             client.Start();
+
+            Console.WriteLine(Global.CloudStorage.LoadC1(0));
 
             while (true) Thread.Sleep(1000000);
         }

--- a/src/Modules/GraphEngine.Client/Trinity.Client.TestProtocols/Module.cs
+++ b/src/Modules/GraphEngine.Client/Trinity.Client.TestProtocols/Module.cs
@@ -13,6 +13,8 @@ namespace Trinity.Client.TestProtocols.Impl
         public override void P1Handler(S1Reader request, S1Writer response)
         {
             Console.WriteLine($"P1Handler reached: {request.foo}, {request.bar}");
+            Console.WriteLine(Global.CloudStorage.LoadC1(0));
+            Console.WriteLine("P1Handler out");
         }
     }
 }

--- a/src/Modules/GraphEngine.Client/Trinity.Client.TestProtocols/Module.cs
+++ b/src/Modules/GraphEngine.Client/Trinity.Client.TestProtocols/Module.cs
@@ -13,8 +13,11 @@ namespace Trinity.Client.TestProtocols.Impl
         public override void P1Handler(S1Reader request, S1Writer response)
         {
             Console.WriteLine($"P1Handler reached: {request.foo}, {request.bar}");
-            Console.WriteLine(Global.CloudStorage.LoadC1(0));
-            Console.WriteLine("P1Handler out");
+            Console.WriteLine(Global.CloudStorage.LoadC1(request.bar));
+            Global.CloudStorage.SaveC1(request.bar + 1, request.foo, request.bar);
+
+            response.foo = request.foo;
+            response.bar = request.bar + 1;
         }
     }
 }

--- a/src/Modules/GraphEngine.Client/Trinity.Client.TestProtocols/TestProtocol.tsl
+++ b/src/Modules/GraphEngine.Client/Trinity.Client.TestProtocols/TestProtocol.tsl
@@ -15,3 +15,9 @@ module TrinityClientTestModule
 {
 	protocol P1;
 }
+
+cell C1
+{
+    string foo;
+    int bar;
+}

--- a/src/Modules/GraphEngine.Client/Trinity.Client.TestServer/Program.cs
+++ b/src/Modules/GraphEngine.Client/Trinity.Client.TestServer/Program.cs
@@ -29,26 +29,26 @@ namespace Trinity.Client.TestServer
             int i = 0;
             while (true)
             {
-                //var client = cmod.Clients.FirstOrDefault();
-                //Console.WriteLine($"{cmod.Clients.Count()} clients");
-                //if (client != null)
-                //{
-                //    try
-                //    {
-                //        using (var msg = new S1Writer("foo", i++))
-                //            client.P1(msg).ContinueWith(t =>
-                //            {
-                //                using (var rsp = t.Result)
-                //                {
-                //                    Console.WriteLine($"Client responded: {rsp.foo}, {rsp.bar}");
-                //                }
-                //            }, TaskContinuationOptions.RunContinuationsAsynchronously);
-                //    }
-                //    catch (Exception ex)
-                //    {
-                //        Console.WriteLine(ex.ToString());
-                //    }
-                //}
+                var client = cmod.Clients.FirstOrDefault();
+                Console.WriteLine($"{cmod.Clients.Count()} clients");
+                if (client != null)
+                {
+                    try
+                    {
+                        using (var msg = new S1Writer("foo", i++))
+                            client.P1(msg).ContinueWith(t =>
+                            {
+                                using (var rsp = t.Result)
+                                {
+                                    Console.WriteLine($"Client responded: {rsp.foo}, {rsp.bar}");
+                                }
+                            }, TaskContinuationOptions.RunContinuationsAsynchronously);
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine(ex.ToString());
+                    }
+                }
                 Thread.Sleep(1000);
             }
         }

--- a/src/Modules/GraphEngine.Client/Trinity.Client.TestServer/Program.cs
+++ b/src/Modules/GraphEngine.Client/Trinity.Client.TestServer/Program.cs
@@ -22,31 +22,33 @@ namespace Trinity.Client.TestServer
             server.RegisterCommunicationModule<TrinityClientTestModule>();
             server.Start();
 
+            Global.LocalStorage.SaveC1(0, "foo", 123);
+
             var cmod = server.GetCommunicationModule<TrinityClientModule.TrinityClientModule>();
             var tmod = server.GetCommunicationModule<TrinityClientTestModule>();
             int i = 0;
             while (true)
             {
-                var client = cmod.Clients.FirstOrDefault();
-                Console.WriteLine($"{cmod.Clients.Count()} clients");
-                if (client != null)
-                {
-                    try
-                    {
-                        using (var msg = new S1Writer("foo", i++))
-                            client.P1(msg).ContinueWith(t =>
-                            {
-                                using (var rsp = t.Result)
-                                {
-                                    Console.WriteLine($"Client responded: {rsp.foo}, {rsp.bar}");
-                                }
-                            }, TaskContinuationOptions.RunContinuationsAsynchronously);
-                    }
-                    catch (Exception ex)
-                    {
-                        Console.WriteLine(ex.ToString());
-                    }
-                }
+                //var client = cmod.Clients.FirstOrDefault();
+                //Console.WriteLine($"{cmod.Clients.Count()} clients");
+                //if (client != null)
+                //{
+                //    try
+                //    {
+                //        using (var msg = new S1Writer("foo", i++))
+                //            client.P1(msg).ContinueWith(t =>
+                //            {
+                //                using (var rsp = t.Result)
+                //                {
+                //                    Console.WriteLine($"Client responded: {rsp.foo}, {rsp.bar}");
+                //                }
+                //            }, TaskContinuationOptions.RunContinuationsAsynchronously);
+                //    }
+                //    catch (Exception ex)
+                //    {
+                //        Console.WriteLine(ex.ToString());
+                //    }
+                //}
                 Thread.Sleep(1000);
             }
         }

--- a/src/Modules/GraphEngine.Client/Trinity.Client/ClientSide/PassThroughIStorage.cs
+++ b/src/Modules/GraphEngine.Client/Trinity.Client/ClientSide/PassThroughIStorage.cs
@@ -9,6 +9,12 @@ using Trinity.Storage;
 
 namespace Trinity.Client
 {
+    /// <summary>
+    /// Simple pass-through IStorage, used to conduct module offset probing etc.
+    /// during client startup sequence.
+    /// When the client is started and registered, the PassThroughIStorage is discarded,
+    /// and replaced by a number of RedirectedIStorage instances.
+    /// </summary>
     internal class PassThroughIStorage : IStorage
     {
         private IMessagePassingEndpoint m_ep;

--- a/src/Modules/GraphEngine.Client/Trinity.Client/ClientSide/RedirectedIStorage.cs
+++ b/src/Modules/GraphEngine.Client/Trinity.Client/ClientSide/RedirectedIStorage.cs
@@ -10,6 +10,12 @@ using Trinity.Storage;
 
 namespace Trinity.Client
 {
+    /// <summary>
+    /// Redirected IStorage, each representing a remote partition.
+    /// Under the hood, it communicates with the remote cloud with
+    /// a shared message passing endpoint (the TrinityClient ep)
+    /// and speaks wrapped messages.
+    /// </summary>
     internal class RedirectedIStorage : IStorage
     {
         private IMessagePassingEndpoint m_ep;
@@ -35,17 +41,10 @@ namespace Trinity.Client
             throw new NotImplementedException();
         }
 
-        public void Dispose()
-        {
-        }
-
         public TrinityErrorCode GetCellType(long cellId, out ushort cellType)
         {
             throw new NotImplementedException();
         }
-
-        public T GetCommunicationModule<T>() where T : CommunicationModule
-            => m_comminst.GetCommunicationModule<T>();
 
         public TrinityErrorCode LoadCell(long cellId, out byte[] cellBuff, out ushort cellType)
         {
@@ -61,6 +60,19 @@ namespace Trinity.Client
         {
             throw new NotImplementedException();
         }
+
+        public unsafe TrinityErrorCode UpdateCell(long cellId, byte* buff, int size)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Dispose()
+        {
+            // note, do not dispose shared comm. endpoint and comm. instance.
+        }
+
+        public T GetCommunicationModule<T>() where T : CommunicationModule
+            => m_comminst.GetCommunicationModule<T>();
 
         public unsafe void SendMessage(byte* message, int size)
         {
@@ -144,11 +156,6 @@ namespace Trinity.Client
             *(int*)(sp.bp + TrinityProtocol.MsgHeader)      = partitionId;
 
             m_mod.SendMessage(m_ep, bufs, sizes, count + 1, out response);
-        }
-
-        public unsafe TrinityErrorCode UpdateCell(long cellId, byte* buff, int size)
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/src/Modules/GraphEngine.Client/Trinity.Client/ClientSide/RedirectedIStorage.cs
+++ b/src/Modules/GraphEngine.Client/Trinity.Client/ClientSide/RedirectedIStorage.cs
@@ -147,7 +147,7 @@ namespace Trinity.Client
             sizes[0]     = TrinityProtocol.MsgHeader + sizeof(int);
             sizes[1]     = size;
 
-            *(int*)header = sizeof(int) + TrinityProtocol.TrinityMsgHeader + size + sizeof(int);
+            *(int*)header = TrinityProtocol.TrinityMsgHeader + sizeof(int) + size;
             *(TrinityMessageType*)(header + TrinityProtocol.MsgTypeOffset) = TrinityMessageType.SYNC;
             *(ushort*)(header + TrinityProtocol.MsgIdOffset) = (ushort)TSL.CommunicationModule.TrinityClientModule.SynReqMessageType.RedirectMessage;
             *(int*)(header + TrinityProtocol.MsgHeader) = partitionId;
@@ -166,7 +166,7 @@ namespace Trinity.Client
             sizes[0]     = TrinityProtocol.MsgHeader + sizeof(int);
             sizes[1]     = size;
 
-            *(int*)header = sizeof(int) + TrinityProtocol.TrinityMsgHeader + size + sizeof(int);
+            *(int*)header = TrinityProtocol.TrinityMsgHeader + sizeof(int) + size;
             *(TrinityMessageType*)(header + TrinityProtocol.MsgTypeOffset) = TrinityMessageType.SYNC_WITH_RSP;
             *(ushort*)(header + TrinityProtocol.MsgIdOffset) = (ushort)TSL.CommunicationModule.TrinityClientModule.SynReqRspMessageType.RedirectMessageWithResponse;
             *(int*)(header + TrinityProtocol.MsgHeader) = partitionId;
@@ -187,7 +187,7 @@ namespace Trinity.Client
             Memory.memcpy(bufs + 1, _bufs, bufs_len);
             Memory.memcpy(sizes + 1, _sizes, sizes_len);
 
-            *(int*)header = sizeof(int) + TrinityProtocol.TrinityMsgHeader + Utils._sum(_sizes, count);
+            *(int*)header = TrinityProtocol.TrinityMsgHeader + sizeof(int) + Utils._sum(_sizes, count);
             *(TrinityMessageType*)(header + TrinityProtocol.MsgTypeOffset) = TrinityMessageType.SYNC;
             *(ushort*)(header + TrinityProtocol.MsgIdOffset) = (ushort)TSL.CommunicationModule.TrinityClientModule.SynReqMessageType.RedirectMessage;
             *(int*)(header + TrinityProtocol.MsgHeader) = partitionId;
@@ -208,7 +208,7 @@ namespace Trinity.Client
             Memory.memcpy(bufs + 1, _bufs, bufs_len);
             Memory.memcpy(sizes + 1, _sizes, sizes_len);
 
-            *(int*)header = sizeof(int) + TrinityProtocol.TrinityMsgHeader + Utils._sum(_sizes, count);
+            *(int*)header = TrinityProtocol.TrinityMsgHeader + sizeof(int) + Utils._sum(_sizes, count);
             *(TrinityMessageType*)(header + TrinityProtocol.MsgTypeOffset) = TrinityMessageType.SYNC_WITH_RSP;
             *(ushort*)(header + TrinityProtocol.MsgIdOffset) = (ushort)TSL.CommunicationModule.TrinityClientModule.SynReqRspMessageType.RedirectMessageWithResponse;
             *(int*)(header + TrinityProtocol.MsgHeader) = partitionId;
@@ -225,7 +225,7 @@ namespace Trinity.Client
             byte** holder = stackalloc byte*[2];
             int*   length = stackalloc int[2];
             PointerHelper sp = PointerHelper.New(header);
-            *sp.ip++ = header_len + size;
+            *sp.ip++ = header_len + size - TrinityProtocol.SocketMsgHeader;
             *sp.sp++ = (short)TrinityMessageType.SYNC_WITH_RSP;
             *sp.sp++ = msgId;
             *sp.lp++ = cellId;
@@ -238,6 +238,8 @@ namespace Trinity.Client
 
             holder[0] = header;
             holder[1] = buff;
+            length[0] = header_len;
+            length[1] = size;
 
             TrinityResponse rsp = null;
             try

--- a/src/Modules/GraphEngine.Client/Trinity.Client/ClientSide/RedirectedIStorage.cs
+++ b/src/Modules/GraphEngine.Client/Trinity.Client/ClientSide/RedirectedIStorage.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using Trinity.Core.Lib;
@@ -18,6 +19,8 @@ namespace Trinity.Client
     /// </summary>
     internal class RedirectedIStorage : IStorage
     {
+        //  !Note, do not send module messages directly through m_ep.
+        //  m_mod will properly align message id offsets.
         private IMessagePassingEndpoint m_ep;
         private CommunicationInstance m_comminst;
         private TrinityClientModule.TrinityClientModule m_mod;
@@ -33,36 +36,7 @@ namespace Trinity.Client
 
         public unsafe TrinityErrorCode AddCell(long cellId, byte* buff, int size, ushort cellType)
         {
-            //header: cellId, size, type
-            int    header_len = TrinityProtocol.MsgHeader + sizeof(long) + sizeof(int) + sizeof(ushort);
-            byte*  header = stackalloc byte[header_len];
-            byte** holder = stackalloc byte*[2];
-            int*   length = stackalloc int[2];
-            PointerHelper sp = PointerHelper.New(header);
-            *sp.ip++ = header_len + size;
-            *sp.sp++ = (short)TrinityMessageType.SYNC_WITH_RSP;
-            *sp.sp++ = (short)TSL.CommunicationModule.TrinityClientModule.SynReqRspMessageType.AddCell;
-            *sp.lp++ = cellId;
-            *sp.ip++ = size;
-            *sp.sp++ = (short)cellType;
-
-            holder[0] = header;
-            holder[1] = buff;
-
-            TrinityResponse rsp = null;
-            try
-            {
-                m_mod.SendMessage(m_ep, holder, length, 2, out rsp);
-                return *(TrinityErrorCode*)rsp.Buffer;
-            }
-            catch
-            {
-                return TrinityErrorCode.E_RPC_EXCEPTION;
-            }
-            finally
-            {
-                rsp?.Dispose();
-            }
+            return _SendCellPayload(cellId, buff, size, cellType, (short)TSL.CommunicationModule.TrinityClientModule.SynReqRspMessageType.AddCell);
         }
 
         public bool Contains(long cellId)
@@ -70,6 +44,7 @@ namespace Trinity.Client
             using (var req = new __CellIdStructWriter(cellId))
             using (var rsp = m_mod.AddCell(0, req))
             {
+                // remote returns E_CELL_FOUND or E_CELL_NOT_FOUND
                 return rsp.code == (int)TrinityErrorCode.E_CELL_FOUND;
             }
         }
@@ -77,7 +52,7 @@ namespace Trinity.Client
         public TrinityErrorCode GetCellType(long cellId, out ushort cellType)
         {
             using (var req = new __CellIdStructWriter(cellId))
-            using (var rsp = m_mod.AddCell(0, req))
+            using (var rsp = m_mod.GetCellType(0, req))
             {
                 if (rsp.code >= 0)
                 {
@@ -92,24 +67,65 @@ namespace Trinity.Client
             }
         }
 
-        public TrinityErrorCode LoadCell(long cellId, out byte[] cellBuff, out ushort cellType)
+        public unsafe TrinityErrorCode LoadCell(long cellId, out byte[] cellBuff, out ushort cellType)
         {
-            throw new NotImplementedException();
+            using (var req = new __CellIdStructWriter(cellId))
+            {
+                TrinityResponse rsp = null;
+                TrinityErrorCode errcode = TrinityErrorCode.E_RPC_EXCEPTION;
+
+                cellBuff = null;
+                cellType = 0;
+
+                try
+                {
+                    var sp = PointerHelper.New(req.buffer);
+                    *sp.ip++ = TrinityProtocol.TrinityMsgHeader + sizeof(long);
+                    *sp.sp++ = (short)TrinityMessageType.SYNC_WITH_RSP;
+                    *sp.sp++ = (short)TSL.CommunicationModule.TrinityClientModule.SynReqRspMessageType.LoadCell;
+
+                    m_mod.SendMessage(m_ep, req.buffer, req.BufferLength, out rsp);
+
+                    sp = PointerHelper.New(rsp.Buffer);
+                    errcode = (TrinityErrorCode)(*sp.ip++);
+                    if (errcode == TrinityErrorCode.E_SUCCESS)
+                    {
+                        var length = *sp.ip++;
+                        cellType = (ushort)(*sp.sp++);
+                        cellBuff = new byte[length];
+                        fixed (byte* p = cellBuff)
+                        {
+                            Memory.memcpy(p, sp.bp, (ulong)length);
+                        }
+                    }
+                    /* otherwise, fails with returned error code */
+                }
+                finally
+                {
+                    rsp?.Dispose();
+                }
+
+                return errcode;
+            }
         }
 
         public TrinityErrorCode RemoveCell(long cellId)
         {
-            throw new NotImplementedException();
+            using (var req = new __CellIdStructWriter(cellId))
+            using (var rsp = m_mod.RemoveCell(0, req))
+            {
+                return (TrinityErrorCode)rsp.code;
+            }
         }
 
         public unsafe TrinityErrorCode SaveCell(long cellId, byte* buff, int size, ushort cellType)
         {
-            throw new NotImplementedException();
+            return _SendCellPayload(cellId, buff, size, cellType, (short)TSL.CommunicationModule.TrinityClientModule.SynReqRspMessageType.SaveCell);
         }
 
         public unsafe TrinityErrorCode UpdateCell(long cellId, byte* buff, int size)
         {
-            throw new NotImplementedException();
+            return _SendCellPayload(cellId, buff, size, null, (short)TSL.CommunicationModule.TrinityClientModule.SynReqRspMessageType.UpdateCell);
         }
 
         public void Dispose()
@@ -122,86 +138,117 @@ namespace Trinity.Client
 
         public unsafe void SendMessage(byte* message, int size)
         {
-            byte* header                                    = stackalloc byte[TrinityProtocol.MsgHeader + sizeof(int)];
-            byte** bufs                                     = stackalloc byte*[2];
-            int* sizes                                      = stackalloc int[2];
+            byte* header = stackalloc byte[TrinityProtocol.MsgHeader + sizeof(int)];
+            byte** bufs  = stackalloc byte*[2];
+            int* sizes   = stackalloc int[2];
 
-            bufs[0]                                         = header;
-            bufs[1]                                         = message;
-            sizes[0]                                        = TrinityProtocol.MsgHeader + sizeof(int);
-            sizes[1]                                        = size;
+            bufs[0]      = header;
+            bufs[1]      = message;
+            sizes[0]     = TrinityProtocol.MsgHeader + sizeof(int);
+            sizes[1]     = size;
 
-            PointerHelper sp                                = PointerHelper.New(header);
-            *sp.ip                                          = size + sizeof(int) + TrinityProtocol.TrinityMsgHeader;
-            *(TrinityMessageType*)(sp.bp + TrinityProtocol.MsgTypeOffset) = TrinityMessageType.SYNC;
-            *(ushort*)(sp.bp + TrinityProtocol.MsgIdOffset) = (ushort)TSL.CommunicationModule.TrinityClientModule.SynReqMessageType.RedirectMessage;
-            *(int*)(sp.bp + TrinityProtocol.MsgHeader)      = partitionId;
+            *(int*)header = sizeof(int) + TrinityProtocol.TrinityMsgHeader + size + sizeof(int);
+            *(TrinityMessageType*)(header + TrinityProtocol.MsgTypeOffset) = TrinityMessageType.SYNC;
+            *(ushort*)(header + TrinityProtocol.MsgIdOffset) = (ushort)TSL.CommunicationModule.TrinityClientModule.SynReqMessageType.RedirectMessage;
+            *(int*)(header + TrinityProtocol.MsgHeader) = partitionId;
 
             m_mod.SendMessage(m_ep, bufs, sizes, 2);
         }
 
         public unsafe void SendMessage(byte* message, int size, out TrinityResponse response)
         {
-            byte* header                                    = stackalloc byte[TrinityProtocol.MsgHeader + sizeof(int)];
-            byte** bufs                                     = stackalloc byte*[2];
-            int* sizes                                      = stackalloc int[2];
+            byte* header = stackalloc byte[TrinityProtocol.MsgHeader + sizeof(int)];
+            byte** bufs  = stackalloc byte*[2];
+            int* sizes   = stackalloc int[2];
 
-            bufs[0]                                         = header;
-            bufs[1]                                         = message;
-            sizes[0]                                        = TrinityProtocol.MsgHeader + sizeof(int);
-            sizes[1]                                        = size;
+            bufs[0]      = header;
+            bufs[1]      = message;
+            sizes[0]     = TrinityProtocol.MsgHeader + sizeof(int);
+            sizes[1]     = size;
 
-            PointerHelper sp                                = PointerHelper.New(header);
-            *sp.ip                                          = size + sizeof(int) + TrinityProtocol.TrinityMsgHeader;
-            *(TrinityMessageType*)(sp.bp + TrinityProtocol.MsgTypeOffset) = TrinityMessageType.SYNC_WITH_RSP;
-            *(ushort*)(sp.bp + TrinityProtocol.MsgIdOffset) = (ushort)TSL.CommunicationModule.TrinityClientModule.SynReqRspMessageType.RedirectMessageWithResponse;
-            *(int*)(sp.bp + TrinityProtocol.MsgHeader)      = partitionId;
+            *(int*)header = sizeof(int) + TrinityProtocol.TrinityMsgHeader + size + sizeof(int);
+            *(TrinityMessageType*)(header + TrinityProtocol.MsgTypeOffset) = TrinityMessageType.SYNC_WITH_RSP;
+            *(ushort*)(header + TrinityProtocol.MsgIdOffset) = (ushort)TSL.CommunicationModule.TrinityClientModule.SynReqRspMessageType.RedirectMessageWithResponse;
+            *(int*)(header + TrinityProtocol.MsgHeader) = partitionId;
 
             m_mod.SendMessage(m_ep, bufs, sizes, 2, out response);
         }
 
         public unsafe void SendMessage(byte** _bufs, int* _sizes, int count)
         {
-            byte* header                                    = stackalloc byte[TrinityProtocol.MsgHeader + sizeof(int)];
-            ulong  bufs_len                                 = (ulong)(sizeof(byte*) * (count + 1));
-            ulong  sizes_len                                = (ulong)(sizeof(int) * (count + 1));
-            byte** bufs                                     = (byte**)Memory.malloc(bufs_len);
-            int*   sizes                                    = (int*)Memory.malloc(sizes_len);
+            byte* header     = stackalloc byte[TrinityProtocol.MsgHeader + sizeof(int)];
+            ulong  bufs_len  = (ulong)(sizeof(byte*) * (count + 1));
+            ulong  sizes_len = (ulong)(sizeof(int) * (count + 1));
+            byte** bufs      = (byte**)Memory.malloc(bufs_len);
+            int*   sizes     = (int*)Memory.malloc(sizes_len);
 
-            bufs[0]                                         = header;
-            sizes[0]                                        = TrinityProtocol.MsgHeader + sizeof(int);
+            bufs[0]          = header;
+            sizes[0]         = TrinityProtocol.MsgHeader + sizeof(int);
             Memory.memcpy(bufs + 1, _bufs, bufs_len);
             Memory.memcpy(sizes + 1, _sizes, sizes_len);
 
-            PointerHelper sp                                = PointerHelper.New(header);
-            *sp.ip                                          = sizeof(int) + TrinityProtocol.TrinityMsgHeader + Utils._sum(_sizes, count);
-            *(TrinityMessageType*)(sp.bp + TrinityProtocol.MsgTypeOffset) = TrinityMessageType.SYNC;
-            *(ushort*)(sp.bp + TrinityProtocol.MsgIdOffset) = (ushort)TSL.CommunicationModule.TrinityClientModule.SynReqMessageType.RedirectMessage;
-            *(int*)(sp.bp + TrinityProtocol.MsgHeader)      = partitionId;
+            *(int*)header = sizeof(int) + TrinityProtocol.TrinityMsgHeader + Utils._sum(_sizes, count);
+            *(TrinityMessageType*)(header + TrinityProtocol.MsgTypeOffset) = TrinityMessageType.SYNC;
+            *(ushort*)(header + TrinityProtocol.MsgIdOffset) = (ushort)TSL.CommunicationModule.TrinityClientModule.SynReqMessageType.RedirectMessage;
+            *(int*)(header + TrinityProtocol.MsgHeader) = partitionId;
 
             m_mod.SendMessage(m_ep, bufs, sizes, count + 1);
         }
 
         public unsafe void SendMessage(byte** _bufs, int* _sizes, int count, out TrinityResponse response)
         {
-            byte* header                                    = stackalloc byte[TrinityProtocol.MsgHeader + sizeof(int)];
-            ulong  bufs_len                                 = (ulong)(sizeof(byte*) * (count + 1));
-            ulong  sizes_len                                = (ulong)(sizeof(int) * (count + 1));
-            byte** bufs                                     = (byte**)Memory.malloc(bufs_len);
-            int*   sizes                                    = (int*)Memory.malloc(sizes_len);
+            byte* header     = stackalloc byte[TrinityProtocol.MsgHeader + sizeof(int)];
+            ulong  bufs_len  = (ulong)(sizeof(byte*) * (count + 1));
+            ulong  sizes_len = (ulong)(sizeof(int) * (count + 1));
+            byte** bufs      = (byte**)Memory.malloc(bufs_len);
+            int*   sizes     = (int*)Memory.malloc(sizes_len);
 
-            bufs[0]                                         = header;
-            sizes[0]                                        = TrinityProtocol.MsgHeader + sizeof(int);
+            bufs[0]          = header;
+            sizes[0]         = TrinityProtocol.MsgHeader + sizeof(int);
             Memory.memcpy(bufs + 1, _bufs, bufs_len);
             Memory.memcpy(sizes + 1, _sizes, sizes_len);
 
-            PointerHelper sp                                = PointerHelper.New(header);
-            *sp.ip                                          = sizeof(int) + TrinityProtocol.TrinityMsgHeader + Utils._sum(_sizes, count);
-            *(TrinityMessageType*)(sp.bp + TrinityProtocol.MsgTypeOffset) = TrinityMessageType.SYNC_WITH_RSP;
-            *(ushort*)(sp.bp + TrinityProtocol.MsgIdOffset) = (ushort)TSL.CommunicationModule.TrinityClientModule.SynReqRspMessageType.RedirectMessageWithResponse;
-            *(int*)(sp.bp + TrinityProtocol.MsgHeader)      = partitionId;
+            *(int*)header = sizeof(int) + TrinityProtocol.TrinityMsgHeader + Utils._sum(_sizes, count);
+            *(TrinityMessageType*)(header + TrinityProtocol.MsgTypeOffset) = TrinityMessageType.SYNC_WITH_RSP;
+            *(ushort*)(header + TrinityProtocol.MsgIdOffset) = (ushort)TSL.CommunicationModule.TrinityClientModule.SynReqRspMessageType.RedirectMessageWithResponse;
+            *(int*)(header + TrinityProtocol.MsgHeader) = partitionId;
 
             m_mod.SendMessage(m_ep, bufs, sizes, count + 1, out response);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe TrinityErrorCode _SendCellPayload(long cellId, byte* buff, int size, ushort? cellType, short msgId)
+        {
+            //header: cellId, size, type
+            int    header_len = TrinityProtocol.MsgHeader + sizeof(long) + sizeof(int) + (cellType.HasValue? sizeof(ushort): 0);
+            byte*  header = stackalloc byte[header_len];
+            byte** holder = stackalloc byte*[2];
+            int*   length = stackalloc int[2];
+            PointerHelper sp = PointerHelper.New(header);
+            *sp.ip++ = header_len + size;
+            *sp.sp++ = (short)TrinityMessageType.SYNC_WITH_RSP;
+            *sp.sp++ = msgId;
+            *sp.lp++ = cellId;
+            *sp.ip++ = size;
+
+            if (cellType.HasValue)
+            {
+                *sp.sp++ = (short)cellType;
+            }
+
+            holder[0] = header;
+            holder[1] = buff;
+
+            TrinityResponse rsp = null;
+            try
+            {
+                m_mod.SendMessage(m_ep, holder, length, 2, out rsp);
+                return *(TrinityErrorCode*)(rsp.Buffer);
+            }
+            finally
+            {
+                rsp?.Dispose();
+            }
         }
     }
 }

--- a/src/Modules/GraphEngine.Client/Trinity.Client/ClientSide/TrinityClient.cs
+++ b/src/Modules/GraphEngine.Client/Trinity.Client/ClientSide/TrinityClient.cs
@@ -68,7 +68,7 @@ namespace Trinity.Client
         {
             if (m_clientfactory == null) { ScanClientConnectionFactory(); }
             m_client = m_clientfactory.ConnectAsync(m_endpoint, this).Result;
-            ClientMemoryCloud.BeginInitialize(m_client, this);
+            (CloudStorage as ClientMemoryCloud).BeginInitialize(m_client, this);
             this.Started += StartPolling;
         }
 
@@ -87,7 +87,7 @@ namespace Trinity.Client
 
         private void RegisterClient()
         {
-            ClientMemoryCloud.EndInitialize();
+            (CloudStorage as ClientMemoryCloud).EndInitialize();
             m_tokensrc = new CancellationTokenSource();
             m_id = Global.CloudStorage.MyInstanceId;
             m_cookie = m_mod.MyCookie;

--- a/src/Modules/GraphEngine.Client/Trinity.Client/ClientSide/TrinityClient.cs
+++ b/src/Modules/GraphEngine.Client/Trinity.Client/ClientSide/TrinityClient.cs
@@ -68,7 +68,7 @@ namespace Trinity.Client
         {
             if (m_clientfactory == null) { ScanClientConnectionFactory(); }
             m_client = m_clientfactory.ConnectAsync(m_endpoint, this).Result;
-            (CloudStorage as ClientMemoryCloud).BeginInitialize(m_client, this);
+            ClientMemoryCloud.Initialize(m_client, this);
             this.Started += StartPolling;
         }
 
@@ -87,7 +87,7 @@ namespace Trinity.Client
 
         private void RegisterClient()
         {
-            (CloudStorage as ClientMemoryCloud).EndInitialize();
+            (CloudStorage as ClientMemoryCloud).RegisterClient();
             m_tokensrc = new CancellationTokenSource();
             m_id = Global.CloudStorage.MyInstanceId;
             m_cookie = m_mod.MyCookie;
@@ -147,7 +147,7 @@ namespace Trinity.Client
                 }
                 if (errno != 0) { return; }
 
-                var pctx = *sp.lp++;
+                var pctx = *sp.lp++; // FIXME pctx is always 0!
                 var msg_len = *sp.ip++;
                 if (msg_len < 0) return; // no events
                 MessageBuff msg_buff = new MessageBuff{ Buffer = sp.bp, BytesReceived = (uint)msg_len };

--- a/src/Modules/GraphEngine.Client/Trinity.Client/README.md
+++ b/src/Modules/GraphEngine.Client/Trinity.Client/README.md
@@ -1,0 +1,5 @@
+﻿# Module GraphEngine.Client
+
+Provides client-side communication instance. In a GraphEngine application,
+a client is by-default not a communication instance -- for that it does
+not possess message handling capabilities. It is 

--- a/src/Modules/GraphEngine.Client/Trinity.Client/README.md
+++ b/src/Modules/GraphEngine.Client/Trinity.Client/README.md
@@ -1,5 +1,0 @@
-﻿# Module GraphEngine.Client
-
-Provides client-side communication instance. In a GraphEngine application,
-a client is by-default not a communication instance -- for that it does
-not possess message handling capabilities. It is 

--- a/src/Modules/GraphEngine.Client/Trinity.Client/ServerSide/HostMemoryCloud.cs
+++ b/src/Modules/GraphEngine.Client/Trinity.Client/ServerSide/HostMemoryCloud.cs
@@ -84,6 +84,7 @@ namespace Trinity.Client.ServerSide
         #endregion
     }
 
+    // TODO make FixedMemoryCloud a component instead of base -- and thus we can support other types of MCs
     [ExtensionPriority(-80)]
     public class HostMemoryCloud : FixedMemoryCloud, IClientRegistry
     {

--- a/src/Modules/GraphEngine.Client/Trinity.Client/Trinity.Client.tsl
+++ b/src/Modules/GraphEngine.Client/Trinity.Client/Trinity.Client.tsl
@@ -39,6 +39,13 @@ struct UnregisterClientRequest
 	int Cookie;
 }
 
+struct CellPayload
+{
+    CellId cellId;
+    List<byte> buff;
+    ushort cellType;
+}
+
 protocol RegisterClient
 {
 	Type: Syn;
@@ -81,6 +88,34 @@ protocol UnregisterClient
 	Response: void;
 }
 
+protocol LoadStorage
+{
+    Type:     Syn;
+    Request:  void;
+    Response: void;
+}
+
+protocol SaveStorage
+{
+    Type:     Syn;
+    Request:  void;
+    Response: void;
+}
+
+protocol ResetStorage
+{
+    Type:     Syn;
+    Request:  void;
+    Response: void;
+}
+
+protocol AddCell
+{
+    Type:     Syn;
+    Request:  CellPayload;
+    Response: ErrorCode;
+}
+
 module TrinityClientModule
 {
 	protocol RegisterClient;
@@ -89,4 +124,8 @@ module TrinityClientModule
 	protocol PostResponse;
 	protocol RedirectMessage;
 	protocol RedirectMessageWithResponse;
+
+    protocol LoadStorage;
+    protocol SaveStorage;
+    protocol ResetStorage;
 }

--- a/src/Modules/GraphEngine.Client/Trinity.Client/Trinity.Client.tsl
+++ b/src/Modules/GraphEngine.Client/Trinity.Client/Trinity.Client.tsl
@@ -39,11 +39,14 @@ struct UnregisterClientRequest
 	int Cookie;
 }
 
-struct CellPayload
+struct __CellIdStruct 
+{ 
+    CellId id; 
+}
+
+struct ErrorCodeResponse
 {
-    CellId cellId;
-    List<byte> buff;
-    ushort cellType;
+    int code;
 }
 
 protocol RegisterClient
@@ -111,9 +114,51 @@ protocol ResetStorage
 
 protocol AddCell
 {
-    Type:     Syn;
-    Request:  CellPayload;
-    Response: ErrorCode;
+    Type: Syn;
+    Request: __CellIdStruct;
+    Response: ErrorCodeResponse;
+}
+
+protocol Contains
+{
+    Type: Syn;
+    Request: __CellIdStruct;
+    Response: ErrorCodeResponse;
+}
+
+protocol GetCellType
+{
+    Type: Syn;
+    Request: __CellIdStruct;
+    Response: ErrorCodeResponse;
+}
+
+protocol LoadCell
+{
+    Type: Syn;
+    Request: __CellIdStruct;
+    Response: __CellIdStruct;
+}
+
+protocol RemoveCell
+{
+    Type: Syn;
+    Request: __CellIdStruct;
+    Response: ErrorCodeResponse;
+}
+
+protocol SaveCell
+{
+    Type: Syn;
+    Request: __CellIdStruct;
+    Response: ErrorCodeResponse;
+}
+
+protocol UpdateCell
+{
+    Type: Syn;
+    Request: __CellIdStruct;
+    Response: ErrorCodeResponse;
 }
 
 module TrinityClientModule
@@ -128,4 +173,11 @@ module TrinityClientModule
     protocol LoadStorage;
     protocol SaveStorage;
     protocol ResetStorage;
+
+    protocol AddCell;
+    protocol Contains;
+    protocol LoadCell;
+    protocol RemoveCell;
+    protocol SaveCell;
+    protocol UpdateCell;
 }

--- a/src/Modules/GraphEngine.Client/Trinity.Client/Trinity.Client.tsl
+++ b/src/Modules/GraphEngine.Client/Trinity.Client/Trinity.Client.tsl
@@ -176,6 +176,7 @@ module TrinityClientModule
 
     protocol AddCell;
     protocol Contains;
+    protocol GetCellType;
     protocol LoadCell;
     protocol RemoveCell;
     protocol SaveCell;

--- a/src/Modules/GraphEngine.Client/Trinity.Client/TrinityClientModule.cs
+++ b/src/Modules/GraphEngine.Client/Trinity.Client/TrinityClientModule.cs
@@ -79,7 +79,13 @@ namespace Trinity.Client.TrinityClientModule
             MessageRegistry.RegisterMessageHandler((ushort)TSL.CommunicationModule.TrinityClientModule.SynReqRspMessageType.PollEvents, PollEvents_impl);
             MessageRegistry.RegisterMessageHandler((ushort)TSL.CommunicationModule.TrinityClientModule.SynReqMessageType.RedirectMessage, RedirectMessage_impl);
             MessageRegistry.RegisterMessageHandler((ushort)TSL.CommunicationModule.TrinityClientModule.SynReqRspMessageType.RedirectMessageWithResponse, RedirectMessageWithResponse_impl);
+
+            MessageRegistry.RegisterMessageHandler((ushort)TSL.CommunicationModule.TrinityClientModule.SynReqRspMessageType.AddCell, AddCell_impl);
+            MessageRegistry.RegisterMessageHandler((ushort)TSL.CommunicationModule.TrinityClientModule.SynReqRspMessageType.LoadCell, LoadCell_impl);
+            MessageRegistry.RegisterMessageHandler((ushort)TSL.CommunicationModule.TrinityClientModule.SynReqRspMessageType.SaveCell, SaveCell_impl);
+            MessageRegistry.RegisterMessageHandler((ushort)TSL.CommunicationModule.TrinityClientModule.SynReqRspMessageType.UpdateCell, UpdateCell_impl);
         }
+
 
         private unsafe void PostResponse_impl(SynReqArgs args)
         {
@@ -218,6 +224,26 @@ namespace Trinity.Client.TrinityClientModule
         {
             throw new NotImplementedException();
         }
+
+        public override void AddCellHandler(__CellIdStructReader request, ErrorCodeResponseWriter response)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void LoadCellHandler(__CellIdStructReader request, __CellIdStructWriter response)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void SaveCellHandler(__CellIdStructReader request, ErrorCodeResponseWriter response)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void UpdateCellHandler(__CellIdStructReader request, ErrorCodeResponseWriter response)
+        {
+            throw new NotImplementedException();
+        }
         #endregion
 
         public override void RegisterClientHandler(RegisterClientRequestReader request, RegisterClientResponseWriter response)
@@ -272,31 +298,9 @@ namespace Trinity.Client.TrinityClientModule
             if (!Global.CloudStorage.ResetStorage()) throw new IOException();
         }
 
-        #region overridden
-        public override void AddCellHandler(__CellIdStructReader request, ErrorCodeResponseWriter response)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override void LoadCellHandler(__CellIdStructReader request, __CellIdStructWriter response)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override void SaveCellHandler(__CellIdStructReader request, ErrorCodeResponseWriter response)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override void UpdateCellHandler(__CellIdStructReader request, ErrorCodeResponseWriter response)
-        {
-            throw new NotImplementedException();
-        }
-        #endregion
-
         public override void ContainsHandler(__CellIdStructReader request, ErrorCodeResponseWriter response)
         {
-            response.code = m_memorycloud.Contains(request.id) ? 1 : 0;
+            response.code = (int)(m_memorycloud.Contains(request.id) ? TrinityErrorCode.E_CELL_FOUND : TrinityErrorCode.E_CELL_NOT_FOUND);
         }
 
         public override void RemoveCellHandler(__CellIdStructReader request, ErrorCodeResponseWriter response)
@@ -304,5 +308,104 @@ namespace Trinity.Client.TrinityClientModule
             response.code = (int)m_memorycloud.RemoveCell(request.id);
         }
 
+        public override void GetCellTypeHandler(__CellIdStructReader request, ErrorCodeResponseWriter response)
+        {
+            var err = (int)m_memorycloud.GetCellType(request.id, out var cellType);
+            response.code = err < 0 ? err : cellType;
+        }
+
+        private unsafe void UpdateCell_impl(SynReqRspArgs args)
+        {
+            /******************************
+             * Protocol: UpdateCell
+             * Request: |8B CellId|4B Size| Payload |
+             * Response: [ 4B TrinityErrorCode header ]
+             ******************************/
+            var sp = PointerHelper.New(args.Buffer + args.Offset);
+            var id = *sp.lp++;
+            var size = *sp.ip++;
+
+            var err = (int)m_memorycloud.UpdateCell(id, sp.bp, size);
+            var buf = (byte*)Memory.malloc(TrinityProtocol.MsgHeader);
+            sp = PointerHelper.New(buf);
+            *sp.ip++ = TrinityProtocol.MsgHeader - TrinityProtocol.SocketMsgHeader;
+            *sp.ip = err;
+            args.Response = new TrinityMessage(buf, TrinityProtocol.MsgHeader);
+        }
+
+        private unsafe void SaveCell_impl(SynReqRspArgs args)
+        {
+            /******************************
+             * Protocol: SaveCell
+             * Request: |8B CellId|4B Size|2B CellType| Payload |
+             * Response: | 4B TrinityErrorCode |
+             ******************************/
+            var sp = PointerHelper.New(args.Buffer + args.Offset);
+            var id = *sp.lp++;
+            var size = *sp.ip++;
+            var type = (ushort)*sp.sp++;
+
+            var err = (int)m_memorycloud.SaveCell(id, sp.bp, size, type);
+            var buf = (byte*)Memory.malloc(TrinityProtocol.MsgHeader);
+            sp = PointerHelper.New(buf);
+            *sp.ip++ = TrinityProtocol.MsgHeader - TrinityProtocol.SocketMsgHeader;
+            *sp.ip = err;
+            args.Response = new TrinityMessage(buf, TrinityProtocol.MsgHeader);
+        }
+
+        private unsafe void AddCell_impl(SynReqRspArgs args)
+        {
+            /******************************
+             * Protocol: AddCell
+             * Request: |8B CellId|4B Size|2B CellType| Payload |
+             * Response: [ 4B TrinityErrorCode header ]
+             ******************************/
+            var sp = PointerHelper.New(args.Buffer + args.Offset);
+            var id = *sp.lp++;
+            var size = *sp.ip++;
+            var type = (ushort)*sp.sp++;
+
+            var err = (int)m_memorycloud.AddCell(id, sp.bp, size, type);
+            var buf = (byte*)Memory.malloc(TrinityProtocol.MsgHeader);
+            sp = PointerHelper.New(buf);
+            *sp.ip++ = TrinityProtocol.MsgHeader - TrinityProtocol.SocketMsgHeader;
+            *sp.ip = err;
+            args.Response = new TrinityMessage(buf, TrinityProtocol.MsgHeader);
+        }
+
+        private unsafe void LoadCell_impl(SynReqRspArgs args)
+        {
+            /******************************
+             * Protocol: LoadCell
+             * Request: |8B CellId|
+             * Response: [ 4B TrinityErrorCode header ] -- if success --> | 4B Size|2B CellType| Payload |
+             ******************************/
+            var id = *(long*)(args.Buffer + args.Offset);
+            var err = m_memorycloud.LoadCell(id, out var cellBuff, out var cellType);
+            if (err == TrinityErrorCode.E_SUCCESS)
+            {
+                var len = TrinityProtocol.MsgHeader + sizeof(int) + cellBuff.Length + sizeof(ushort);
+                var buf = (byte*)Memory.malloc((ulong)len);
+                var sp = PointerHelper.New(buf);
+                *sp.ip++ = len - TrinityProtocol.SocketMsgHeader;
+                *sp.ip++ = (int)err;
+                *sp.ip++ = cellBuff.Length;
+                *sp.sp++ = (short)cellType;
+                fixed(byte* p = cellBuff)
+                {
+                    Memory.memcpy(sp.bp, p, (ulong)cellBuff.Length);
+                }
+
+                args.Response = new TrinityMessage(buf, len);
+            }
+            else
+            {
+                var buf = (byte*)Memory.malloc(TrinityProtocol.MsgHeader);
+                var sp = PointerHelper.New(buf);
+                *sp.ip++ = TrinityProtocol.MsgHeader - TrinityProtocol.SocketMsgHeader;
+                *sp.ip = (int)err;
+                args.Response = new TrinityMessage(buf, TrinityProtocol.MsgHeader);
+            }
+        }
     }
 }

--- a/src/Modules/GraphEngine.Client/Trinity.Client/TrinityClientModule.cs
+++ b/src/Modules/GraphEngine.Client/Trinity.Client/TrinityClientModule.cs
@@ -271,5 +271,38 @@ namespace Trinity.Client.TrinityClientModule
         {
             if (!Global.CloudStorage.ResetStorage()) throw new IOException();
         }
+
+        #region overridden
+        public override void AddCellHandler(__CellIdStructReader request, ErrorCodeResponseWriter response)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void LoadCellHandler(__CellIdStructReader request, __CellIdStructWriter response)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void SaveCellHandler(__CellIdStructReader request, ErrorCodeResponseWriter response)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void UpdateCellHandler(__CellIdStructReader request, ErrorCodeResponseWriter response)
+        {
+            throw new NotImplementedException();
+        }
+        #endregion
+
+        public override void ContainsHandler(__CellIdStructReader request, ErrorCodeResponseWriter response)
+        {
+            response.code = m_memorycloud.Contains(request.id) ? 1 : 0;
+        }
+
+        public override void RemoveCellHandler(__CellIdStructReader request, ErrorCodeResponseWriter response)
+        {
+            response.code = (int)m_memorycloud.RemoveCell(request.id);
+        }
+
     }
 }

--- a/src/Modules/GraphEngine.Client/Trinity.Client/TrinityClientModule.cs
+++ b/src/Modules/GraphEngine.Client/Trinity.Client/TrinityClientModule.cs
@@ -11,6 +11,7 @@ using Trinity.Extension;
 using Trinity.Network.Messaging;
 using Trinity.Storage;
 using System.Runtime.CompilerServices;
+using System.IO;
 
 namespace Trinity.Client.TrinityClientModule
 {
@@ -254,6 +255,21 @@ namespace Trinity.Client.TrinityClientModule
         {
             if (m_client_storages.TryGetValue(cookie, out var storage) && instanceId == storage.InstanceId) return storage;
             throw new ClientInstanceNotFoundException();
+        }
+
+        public override void LoadStorageHandler()
+        {
+            if (!Global.CloudStorage.LoadStorage()) throw new IOException();
+        }
+
+        public override void SaveStorageHandler()
+        {
+            if (!Global.CloudStorage.SaveStorage()) throw new IOException();
+        }
+
+        public override void ResetStorageHandler()
+        {
+            if (!Global.CloudStorage.ResetStorage()) throw new IOException();
         }
     }
 }


### PR DESCRIPTION
This PR finishes the IKeyValueStore interface in TrinityClient. Beforehand, these methods throw not implemented exception. Also, the messaging protocols are re-aligned to adapt to latest communication ABI standard.