### PR TITLE
Trinity.Core: redirect localstorage messages to native dispatcher

### DIFF
--- a/src/Trinity.C/src/Events/Events.cpp
+++ b/src/Trinity.C/src/Events/Events.cpp
@@ -182,3 +182,4 @@ namespace Trinity
 DLL_EXPORT TrinityErrorCode StartEventLoop() { return Trinity::Events::start_eventloop(); }
 DLL_EXPORT TrinityErrorCode StopEventLoop() { return Trinity::Events::stop_eventloop(); }
 DLL_EXPORT TrinityErrorCode RegisterMessageHandler(uint16_t msgId, void * handler) { return Trinity::Events::register_handler(msgId, (Trinity::Events::message_handler_t *)handler); }
+DLL_EXPORT void LocalSendMessage(Trinity::Events::message_t* message) { Trinity::Events::s_message_handlers[*(uint16_t*)message->buf](message); }

--- a/src/Trinity.C/src/Events/Events.h
+++ b/src/Trinity.C/src/Events/Events.h
@@ -29,6 +29,8 @@ namespace Trinity
             Shutdown,
             Wakeup,
             Resume,
+            Read,
+            Write,
         };
 
         // This is for data exchange between Events subsystem and message handlers.

--- a/src/Trinity.Core/Storage/LocalMemoryStorage/LocalMemoryStorage.Message.cs
+++ b/src/Trinity.Core/Storage/LocalMemoryStorage/LocalMemoryStorage.Message.cs
@@ -15,69 +15,34 @@ using Trinity;
 using Trinity.Network.Messaging;
 using Trinity.Network.Sockets;
 using Trinity.Core.Lib;
-using System.Runtime.CompilerServices;
 using Trinity.Network;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace Trinity.Storage
 {
     public unsafe partial class LocalMemoryStorage : IStorage
     {
+        [DllImport(TrinityC.AssemblyName)]
+        private static extern void LocalSendMessage(MessageBuff* lpmsg);
+
         /// <inheritdoc/>
         public void SendMessage(byte* message, int size)
         {
-            TrinityMessageType msgType = *(TrinityMessageType*)(message+TrinityProtocol.MsgTypeOffset);
-            ushort msgId = *(ushort*)(message + TrinityProtocol.MsgIdOffset);
-            TrinityErrorCode msgProcessResult;
+            MessageBuff buff = new MessageBuff();
+            buff.Buffer = message;
+            buff.Length = (uint)size;
 
-            switch (msgType)
+            LocalSendMessage(&buff);
+
+            if(buff.Length != sizeof(TrinityErrorCode))
             {
-                case TrinityMessageType.PRESERVED_SYNC:
-                    SynReqArgs preserved_sync_args = new SynReqArgs(message,
-                        TrinityProtocol.MsgHeader, size - TrinityProtocol.MsgHeader,
-                        MessageHandlers.DefaultParser.preserved_sync_handlers[msgId]);
-                    msgProcessResult = preserved_sync_args.MessageProcess();
-                    break;
-
-                case TrinityMessageType.SYNC:
-                    SynReqArgs sync_args = new SynReqArgs(message,
-                        TrinityProtocol.MsgHeader,
-                        size - TrinityProtocol.MsgHeader,
-                        MessageHandlers.DefaultParser.sync_handlers[msgId]);
-                    msgProcessResult = sync_args.MessageProcess();
-                    break;
-
-                case TrinityMessageType.PRESERVED_ASYNC:
-                    {
-                        AsynReqArgs aut_request = new AsynReqArgs(message,
-                            TrinityProtocol.MsgHeader,
-                            size - TrinityProtocol.MsgHeader,
-                            MessageHandlers.DefaultParser.preserved_async_handlers[msgId]);
-                        msgProcessResult = aut_request.AsyncProcessMessage();
-                    }
-                    break;
-                case TrinityMessageType.ASYNC:
-                    {
-                        AsynReqArgs aut_request = new AsynReqArgs(message,
-                            TrinityProtocol.MsgHeader,
-                            size - TrinityProtocol.MsgHeader,
-                            MessageHandlers.DefaultParser.async_handlers[msgId]);
-                        msgProcessResult = aut_request.AsyncProcessMessage();
-                    }
-                    break;
-                case TrinityMessageType.ASYNC_WITH_RSP:
-                    {
-                        AsynReqRspArgs async_rsp_args = new AsynReqRspArgs(message,
-                            TrinityProtocol.MsgHeader,
-                            size - TrinityProtocol.MsgHeader,
-                            MessageHandlers.DefaultParser.async_rsp_handlers[msgId]);
-                        msgProcessResult = async_rsp_args.AsyncProcessMessage();
-                    }
-                    break;
-                default:
-                    throw new IOException("Wrong message type.");
+                throw new IOException("LocalSendMessage responds with unexpected payload");
             }
 
-            if (msgProcessResult == TrinityErrorCode.E_RPC_EXCEPTION)
+            TrinityErrorCode msgProcessResult = *(TrinityErrorCode*)buff.Buffer;
+
+            if (msgProcessResult != TrinityErrorCode.E_SUCCESS)
             {
                 throw new IOException("Local message handler throws an exception.");
             }
@@ -86,33 +51,21 @@ namespace Trinity.Storage
         /// <inheritdoc/>
         public void SendMessage(byte* message, int size, out TrinityResponse response)
         {
-            TrinityMessageType msgType = *(TrinityMessageType*)(message+TrinityProtocol.MsgTypeOffset);
-            ushort msgId = *(ushort*)(message+TrinityProtocol.MsgIdOffset);
-            SynReqRspArgs sync_rsp_args;
-            TrinityErrorCode msgProcessResult;
+            MessageBuff buff = new MessageBuff();
+            buff.Buffer = message;
+            buff.Length = (uint)size;
 
-            if (msgType == TrinityMessageType.PRESERVED_SYNC_WITH_RSP)
-            {
-                sync_rsp_args = new SynReqRspArgs(message,
-                    TrinityProtocol.MsgHeader,
-                    size - TrinityProtocol.MsgHeader,
-                    MessageHandlers.DefaultParser.preserved_sync_rsp_handlers[msgId]);
-            }
-            else// msgType == TrinityMessageType.SYNC_WITH_RSP
-            {
-                sync_rsp_args = new SynReqRspArgs(message,
-                    TrinityProtocol.MsgHeader,
-                    size - TrinityProtocol.MsgHeader,
-                    MessageHandlers.DefaultParser.sync_rsp_handlers[msgId]);
-            }
-            msgProcessResult = sync_rsp_args.MessageProcess();
-            if (msgProcessResult == TrinityErrorCode.E_SUCCESS)
-            {
-                response = new TrinityResponse(sync_rsp_args.Response);
-            }
-            else//  msgProcessResult == TrinityErrorCode.E_RPC_EXCEPTION
+            LocalSendMessage(&buff);
+
+            int response_len = *(int*)buff.Buffer;
+            if(buff.Length != response_len + sizeof(int))
             {
                 throw new IOException("Local message handler throws an exception.");
+            }
+            else
+            {
+                TrinityMessage rsp_message = new TrinityMessage(buff.Buffer, (int)buff.Length);
+                response = new TrinityResponse(rsp_message);
             }
         }
 
@@ -122,46 +75,8 @@ namespace Trinity.Storage
             byte* buf;
             int len;
             _serialize(message, sizes, count, out buf, out len);
-
-            TrinityMessageType msgType = *(TrinityMessageType*)(buf + TrinityProtocol.MsgTypeOffset);
-            ushort msgId = *(ushort*)(buf + TrinityProtocol.MsgIdOffset);
-
-            // For async messages, we omit the buffer copy, use the serialized buffer directly.
-            switch (msgType)
-            {
-                case TrinityMessageType.ASYNC:
-                    {
-                        AsynReqArgs aut_request = new AsynReqArgs(
-                            MessageHandlers.DefaultParser.async_handlers[msgId],
-                            buf,
-                            TrinityProtocol.MsgHeader,
-                            len - TrinityProtocol.MsgHeader);
-                        if (aut_request.AsyncProcessMessage() == TrinityErrorCode.E_RPC_EXCEPTION)
-                        {
-                            throw new IOException("Local message handler throws an exception.");
-                        }
-                    }
-                    break;
-                case TrinityMessageType.ASYNC_WITH_RSP:
-                    {
-                        AsynReqRspArgs async_rsp_args = new AsynReqRspArgs(
-                            MessageHandlers.DefaultParser.async_rsp_handlers[msgId],
-                            buf,
-                            TrinityProtocol.MsgHeader,
-                            len - TrinityProtocol.MsgHeader);
-                        if (async_rsp_args.AsyncProcessMessage() == TrinityErrorCode.E_RPC_EXCEPTION)
-                        {
-                            throw new IOException("Local message handler throws an exception.");
-                        }
-                    }
-                    break;
-                default:
-                    {
-                        SendMessage(buf, len);
-                        CMemory.C_free(buf);
-                    }
-                    break;
-            }
+            SendMessage(buf, len);
+            CMemory.C_free(buf);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
This PR addresses the inconsistency between local/remote message dispatching, that remote messages were always dispatched natively while local messages by LocalMemoryStorage.


This PR unifies the two, routing all messages through a shared dispatcher.
It then follows that message types other than TrinityMessage (GraphMachine etc.) are also supported locally.
