### PR TITLE
Trinity.C: MTHash: recover from NOMEM condition instead of exit

### DIFF
--- a/src/Trinity.C/include/Trinity/Storage.h
+++ b/src/Trinity.C/include/Trinity/Storage.h
@@ -41,24 +41,5 @@ namespace Storage
 #pragma pack(pop)
         }
 
-        namespace Enumeration
-        {
-            typedef struct
-            {
-                /** Public members visible to C# */
-                char*       CellPtr;
-                cellid_t    CellId;
-                int32_t     CellEntryIndex;
-                uint16_t    CellType;
-                /**         CellSize should be obtained from mt_enumerator if necessary */
-                //////////////////////////////////
-                /** Internal members */
-                uint16_t             mt_enumerator_active; // TRUE if mt_enumerator is initialized; FALSE if mt_enumerator called Invalidate()
-                MTHash*              mt_hash;
-                MT_SHADOW_ENUMERATOR mt_enumerator;
-                //////////////////////////////////
-            }LOCAL_MEMORY_STORAGE_ENUMERATOR, *PLOCAL_MEMORY_STORAGE_ENUMERATOR;
-        }
-
     }
 }

--- a/src/Trinity.C/include/Trinity/Storage.h
+++ b/src/Trinity.C/include/Trinity/Storage.h
@@ -40,5 +40,25 @@ namespace Storage
             }LOG_RECORD_HEADER, *PLOG_RECORD_HEADER;
 #pragma pack(pop)
         }
+
+        namespace Enumeration
+        {
+            typedef struct
+            {
+                /** Public members visible to C# */
+                char*       CellPtr;
+                cellid_t    CellId;
+                int32_t     CellEntryIndex;
+                uint16_t    CellType;
+                /**         CellSize should be obtained from mt_enumerator if necessary */
+                //////////////////////////////////
+                /** Internal members */
+                uint16_t             mt_enumerator_active; // TRUE if mt_enumerator is initialized; FALSE if mt_enumerator called Invalidate()
+                MTHash*              mt_hash;
+                MT_SHADOW_ENUMERATOR mt_enumerator;
+                //////////////////////////////////
+            }LOCAL_MEMORY_STORAGE_ENUMERATOR, *PLOCAL_MEMORY_STORAGE_ENUMERATOR;
+        }
+
     }
 }

--- a/src/Trinity.C/src/Storage/LocalStorage/LocalMemoryStorage.h
+++ b/src/Trinity.C/src/Storage/LocalStorage/LocalMemoryStorage.h
@@ -92,7 +92,6 @@ namespace Storage
         /////////////////////////////////////
 
         // DiskIO
-
         String GetPrimaryStorageSlot();
         String GetSecondaryStorageSlot();
 
@@ -101,7 +100,6 @@ namespace Storage
         ALLOC_THREAD_CTX TrinityErrorCode ResetStorage();
 
         // Write-ahead logging
-
         namespace Logging
         {
             void ComputeChecksum(PLOG_RECORD_HEADER plog, char* bufferPtr);
@@ -119,22 +117,6 @@ namespace Storage
 
         namespace Enumeration
         {
-            typedef struct
-            {
-                /** Public members visible to C# */
-                char*       CellPtr;
-                cellid_t    CellId;
-                int32_t     CellEntryIndex;
-                uint16_t    CellType;
-                /**         CellSize should be obtained from mt_enumerator if necessary */
-                //////////////////////////////////
-                /** Internal members */
-                uint16_t             mt_enumerator_active; // TRUE if mt_enumerator is initialized; FALSE if mt_enumerator called Invalidate()
-                MTHash*              mt_hash;
-                MT_SHADOW_ENUMERATOR mt_enumerator;
-                //////////////////////////////////
-            }LOCAL_MEMORY_STORAGE_ENUMERATOR, *PLOCAL_MEMORY_STORAGE_ENUMERATOR;
-
             TrinityErrorCode Allocate(OUT PLOCAL_MEMORY_STORAGE_ENUMERATOR &pp_enum);
             TrinityErrorCode Deallocate(IN  PLOCAL_MEMORY_STORAGE_ENUMERATOR p_enum);
             TrinityErrorCode Reset(IN  PLOCAL_MEMORY_STORAGE_ENUMERATOR p_enum);

--- a/src/Trinity.C/src/Storage/LocalStorage/LocalMemoryStorage.h
+++ b/src/Trinity.C/src/Storage/LocalStorage/LocalMemoryStorage.h
@@ -117,6 +117,22 @@ namespace Storage
 
         namespace Enumeration
         {
+            typedef struct
+            {
+                /** Public members visible to C# */
+                char*       CellPtr;
+                cellid_t    CellId;
+                int32_t     CellEntryIndex;
+                uint16_t    CellType;
+                /**         CellSize should be obtained from mt_enumerator if necessary */
+                //////////////////////////////////
+                /** Internal members */
+                uint16_t             mt_enumerator_active; // TRUE if mt_enumerator is initialized; FALSE if mt_enumerator called Invalidate()
+                MTHash*              mt_hash;
+                MT_SHADOW_ENUMERATOR mt_enumerator;
+                //////////////////////////////////
+            }LOCAL_MEMORY_STORAGE_ENUMERATOR, *PLOCAL_MEMORY_STORAGE_ENUMERATOR;
+
             TrinityErrorCode Allocate(OUT PLOCAL_MEMORY_STORAGE_ENUMERATOR &pp_enum);
             TrinityErrorCode Deallocate(IN  PLOCAL_MEMORY_STORAGE_ENUMERATOR p_enum);
             TrinityErrorCode Reset(IN  PLOCAL_MEMORY_STORAGE_ENUMERATOR p_enum);

--- a/src/Trinity.C/src/Storage/MTHash/MTHash.CellInfo.cpp
+++ b/src/Trinity.C/src/Storage/MTHash/MTHash.CellInfo.cpp
@@ -105,6 +105,9 @@ namespace Storage
         {
             // Add new cell
             int32_t free_entry = FindFreeEntry();
+            if (free_entry == -1)
+            { return TrinityErrorCode::E_NOMEM; }
+
             TrinityErrorCode eResult = TryGetEntryLock(free_entry);
             assert(eResult == TrinityErrorCode::E_SUCCESS);
 
@@ -161,6 +164,8 @@ namespace Storage
             [this, cellId, type, size, /* OUT */ &cellPtr, &entryIndex](const uint32_t bucket_index) 
         {
             int32_t free_entry = FindFreeEntry();
+            if (free_entry == -1)
+            { return TrinityErrorCode::E_NOMEM; }
             TrinityErrorCode eResult = TryGetEntryLock(free_entry);
             assert(eResult == TrinityErrorCode::E_SUCCESS);
 
@@ -312,6 +317,8 @@ namespace Storage
         {
 #pragma region add new cell
             int32_t free_entry = FindFreeEntry();
+            if (free_entry == -1)
+            { return TrinityErrorCode::E_NOMEM; }
             TrinityErrorCode eResult = TryGetEntryLock(free_entry);
             assert(eResult == TrinityErrorCode::E_SUCCESS);
 

--- a/src/Trinity.C/src/Storage/MTHash/MTHash.Resize.cpp
+++ b/src/Trinity.C/src/Storage/MTHash/MTHash.Resize.cpp
@@ -7,7 +7,7 @@
 
 namespace Storage
 {
-    void MTHash::Expand(bool force)
+    TrinityErrorCode MTHash::Expand(bool force)
     {
         EntryAllocLock->lock();
         uint32_t CurrentEntryCount = ExtendedInfo->EntryCount.load();
@@ -15,13 +15,13 @@ namespace Storage
         if ((!force) && ((uint32_t)ExtendedInfo->NonEmptyEntryCount.load() < CurrentEntryCount))
         {
             EntryAllocLock->unlock();
-            return;
+            return TrinityErrorCode::E_SUCCESS;
         }
 
         if ((CurrentEntryCount + UInt32_Contants::GuardedEntryCount) >= TrinityConfig::ReserveEntriesPerMTHash())
         {
-			//XXX should not exit here
-            Trinity::Diagnostics::FatalError(1, "Memory Trunk {0} is out of Memory::", memory_trunk->TrunkId);
+            WriteLine(LogLevel::Error, "Memory Trunk {0} is out of Memory", memory_trunk->TrunkId);
+            return TrinityErrorCode::E_NOMEM;
         }
 
         uint32_t expanded_entry_count = CurrentEntryCount + UInt32_Contants::EntryExpandUnit;
@@ -40,5 +40,7 @@ namespace Storage
 
         ExtendedInfo->EntryCount.store(expanded_entry_count);
         EntryAllocLock->unlock();
+
+        return TrinityErrorCode::E_SUCCESS;
     }
 }

--- a/src/Trinity.C/src/Storage/MTHash/MTHash.h
+++ b/src/Trinity.C/src/Storage/MTHash/MTHash.h
@@ -174,10 +174,19 @@ namespace Storage
 
         void MarkTrunkDirty();
 
-        void Expand(bool force);
+        // Resize and expand the entry arrays so that the current capacity
+        // is larger than the number of non-empty entries allocated.
+        // Returns E_SUCCESS if the expansion succeeds, or is unnecessary.
+        // Returns E_NOMEM if the MTHash is full.
+        TrinityErrorCode Expand(bool force);
 
         // Thread-safe
         void                         FreeEntry(int32_t entry_index);
+        // Finds a free entry from either the free 
+        // entry list, or freshly from the empty entries.
+        // The MTHash may need to expand to allocate more empty entries.
+        // Returns the index of the found entry.
+        // Returns -1 if the MTHash is full.
         int32_t                      FindFreeEntry();
         int32_t                      Count();
         // Lock-related


### PR DESCRIPTION
This PR fix an unwanted behavior, that when a MTHash runs out of space, it kills the whole process during expansion.